### PR TITLE
feat: add fluent state and input builders

### DIFF
--- a/src/.exports.ts
+++ b/src/.exports.ts
@@ -1,5 +1,6 @@
 export * from "./circuits/.exports.ts";
 export * from "./eac/.exports.ts";
+export * from "./fluent/_exports.ts";
 export * from "./indexing/_exports.ts";
 export * from "./memory/_exports.ts";
 export * from "./plugins/.exports.ts";

--- a/src/fluent/_exports.ts
+++ b/src/fluent/_exports.ts
@@ -1,0 +1,3 @@
+export * from "./EaCFluentBuilder.ts";
+export * from "./EaCFluentBuilderProxy.ts";
+export * from "./state/_exports.ts";

--- a/src/fluent/state/InputBuilder.ts
+++ b/src/fluent/state/InputBuilder.ts
@@ -1,0 +1,13 @@
+import { z, type ZodObject, type ZodRawShape } from "../../src.deps.ts";
+import { InferSynapticState } from "../../utils/types.ts";
+
+export function InputBuilder<
+  TStateSchema extends Record<string, unknown>,
+  TAdditional extends ZodRawShape,
+>(_state: TStateSchema, additional: TAdditional) {
+  const schema = z.object(additional) as ZodObject<TAdditional>;
+  type Input =
+    & Partial<InferSynapticState<TStateSchema>>
+    & z.infer<typeof schema>;
+  return { Schema: schema, Type: {} as Input };
+}

--- a/src/fluent/state/StateBuilder.ts
+++ b/src/fluent/state/StateBuilder.ts
@@ -1,0 +1,35 @@
+import { Annotation } from "../../src.deps.ts";
+
+export interface StateBuilderFieldOptions<T> {
+  reducer?: (state: T, update: T) => T;
+  default?: () => T;
+}
+
+export class StateBuilder<
+  TState extends Record<string, unknown> = Record<PropertyKey, never>,
+> {
+  protected schema: Record<string, ReturnType<typeof Annotation>> = {};
+
+  Field<K extends string, V>(
+    name: K,
+    options: StateBuilderFieldOptions<V>,
+  ): StateBuilder<TState & Record<K, V>> {
+    this.schema[name] = Annotation<V>({
+      default: options.default,
+      reducer: options.reducer,
+    });
+
+    return this as unknown as StateBuilder<TState & Record<K, V>>;
+  }
+
+  Build() {
+    return this.schema;
+  }
+}
+
+export function buildState<T>(
+  builder: (sb: StateBuilder) => StateBuilder<T>,
+): Record<string, ReturnType<typeof Annotation>> {
+  const sb = builder(new StateBuilder());
+  return sb.Build();
+}

--- a/src/fluent/state/_exports.ts
+++ b/src/fluent/state/_exports.ts
@@ -1,0 +1,2 @@
+export * from "./StateBuilder.ts";
+export * from "./InputBuilder.ts";

--- a/tests/circuits/graphs/how-tos/branching.ts
+++ b/tests/circuits/graphs/how-tos/branching.ts
@@ -1,5 +1,4 @@
 import {
-  Annotation,
   assert,
   assertEquals,
   END,
@@ -7,6 +6,7 @@ import {
   Runnable,
   START,
 } from "../../../tests.deps.ts";
+import { StateBuilder } from "../../../../src/fluent/state/StateBuilder.ts";
 import { buildTestIoC } from "../../../test-eac-setup.ts";
 import { EaCPassthroughNeuron } from "../../../../src/eac/neurons/EaCPassthroughNeuron.ts";
 import { EaCNeuron } from "../../../../src/eac/EaCNeuron.ts";
@@ -37,6 +37,24 @@ Deno.test("Graph Branching Circuits", async (t) => {
     };
   };
 
+  const fanOutFanInState = new StateBuilder()
+    .Field("aggregate", {
+      reducer: (x: string[], y: string[]) => x.concat(y),
+      default: () => [],
+    })
+    .Build();
+
+  const conditionalState = new StateBuilder()
+    .Field("aggregate", {
+      reducer: (x: string[], y: string[]) => x.concat(y),
+      default: () => [],
+    })
+    .Field("which", {
+      reducer: (x: string, y: string) => (y ? y : x),
+      default: () => "",
+    })
+    .Build();
+
   const eac = {
     Circuits: {
       $neurons: {
@@ -48,12 +66,7 @@ Deno.test("Graph Branching Circuits", async (t) => {
         Details: {
           Type: "Graph",
           Priority: 100,
-          State: {
-            aggregate: Annotation<string[]>({
-              reducer: (x, y) => x.concat(y),
-              default: () => [],
-            }),
-          },
+          State: fanOutFanInState,
           Neurons: {
             a: {
               BootstrapInput: loadSimpleBootstrap("A"),
@@ -81,16 +94,7 @@ Deno.test("Graph Branching Circuits", async (t) => {
         Details: {
           Type: "Graph",
           Priority: 100,
-          State: {
-            aggregate: Annotation<string[]>({
-              reducer: (x, y) => x.concat(y),
-              default: () => [],
-            }),
-            which: Annotation<string>({
-              reducer: (x, y) => (y ? y : x),
-              default: () => "",
-            }),
-          },
+          State: conditionalState,
           Neurons: {
             a: {
               BootstrapInput: loadSimpleBootstrap("A"),

--- a/tests/circuits/neurons/EaCChatPromptNeuron.tests.ts
+++ b/tests/circuits/neurons/EaCChatPromptNeuron.tests.ts
@@ -5,7 +5,6 @@ import FathymSynapticPlugin from "../../../src/plugins/FathymSynapticPlugin.ts";
 import { buildTestIoC } from "../../test-eac-setup.ts";
 import {
   AIMessage,
-  Annotation,
   assert,
   assertEquals,
   BaseMessage,
@@ -18,30 +17,41 @@ import {
   START,
   z,
 } from "../../tests.deps.ts";
+import {
+  InferSynapticState,
+  InputBuilder,
+  StateBuilder,
+} from "../../../mod.ts";
 import { EaCGraphCircuitDetails } from "../../../src/eac/EaCGraphCircuitDetails.ts";
-import { InferSynapticState } from "../../../src/utils/types.ts";
 import { EaCDenoKVSaverPersistenceDetails } from "../../../src/eac/EaCDenoKVSaverPersistenceDetails.ts";
 import { EaCAzureOpenAILLMDetails } from "../../../src/eac/llms/EaCAzureOpenAILLMDetails.ts";
 import { EaCLLMNeuron } from "../../../src/eac/neurons/EaCLLMNeuron.ts";
 
-export const LovelaceSourceInformationInputSchema = z.object({
-  Input: z.string().optional(),
-});
-
-export type LovelaceSourceInformationInputSchema = z.infer<
-  typeof LovelaceSourceInformationInputSchema
->;
-
-export const LovelaceSourceInformationGraphStateSchema = {
-  Messages: Annotation<BaseMessage[]>({
-    reducer: (x, y) => x.concat(y),
+const LovelaceSourceInformationGraphStateBuilder = new StateBuilder()
+  .Field("Messages", {
+    reducer: (x: BaseMessage[], y: BaseMessage[]) => x.concat(y),
     default: () => [],
-  }),
-};
+  });
+
+export const LovelaceSourceInformationGraphStateSchema =
+  LovelaceSourceInformationGraphStateBuilder.Build();
 
 export type LovelaceSourceInformationGraphStateSchema = InferSynapticState<
   typeof LovelaceSourceInformationGraphStateSchema
 >;
+
+const LovelaceSourceInformationInput = InputBuilder(
+  LovelaceSourceInformationGraphStateSchema,
+  {
+    Input: z.string().optional(),
+  },
+);
+
+export const LovelaceSourceInformationInputSchema =
+  LovelaceSourceInformationInput.Schema;
+
+export type LovelaceSourceInformationInputSchema =
+  typeof LovelaceSourceInformationInput.Type;
 
 Deno.test("EaCChatPromptNeuron Tests", async (t) => {
   const eac = {

--- a/tests/fluent/state/state-builder.tests.ts
+++ b/tests/fluent/state/state-builder.tests.ts
@@ -1,0 +1,24 @@
+import { assertEquals, z, zodToJsonSchema } from "../../tests.deps.ts";
+import { InputBuilder, StateBuilder } from "../../../mod.ts";
+
+Deno.test("State and Input builders", () => {
+  const state = new StateBuilder()
+    .Field("messages", {
+      reducer: (x: string[], y: string[]) => x.concat(y),
+      default: () => [],
+    })
+    .Build();
+
+  const input = InputBuilder(state, {
+    Input: z.string().optional(),
+  });
+
+  const manual = z.object({
+    Input: z.string().optional(),
+  });
+
+  assertEquals(
+    zodToJsonSchema(input.Schema),
+    zodToJsonSchema(manual),
+  );
+});


### PR DESCRIPTION
## Summary
- add StateBuilder to generate annotated state definitions
- introduce InputBuilder to derive input schemas from state and extra fields
- refactor sample circuits to use new builders and add tests

## Testing
- `deno test tests/fluent/state/state-builder.tests.ts` *(fails: JSR package manifest for '@std/dotenv' failed to load)*
- `deno test tests/circuits/graphs/how-tos/branching.ts` *(fails: JSR package manifest for '@std/dotenv' failed to load)*

------
https://chatgpt.com/codex/tasks/task_b_6896a043fb80832684f6580756a95d54