### PR TITLE
feat: add linear circuit builder

### DIFF
--- a/src/fluent/_exports.ts
+++ b/src/fluent/_exports.ts
@@ -1,3 +1,4 @@
 export * from "./EaCFluentBuilder.ts";
 export * from "./EaCFluentBuilderProxy.ts";
 export * from "./state/_exports.ts";
+export * from "./circuits/_exports.ts";

--- a/src/fluent/circuits/GraphCircuitBuilder.ts
+++ b/src/fluent/circuits/GraphCircuitBuilder.ts
@@ -1,0 +1,80 @@
+import {
+  EaCGraphCircuitDetails,
+  EaCGraphCircuitEdge,
+  EaCGraphCircuitEdgeLike,
+} from "../../eac/EaCGraphCircuitDetails.ts";
+import { StateDefinition } from "../../src.deps.ts";
+import { NeuronBuilder } from "./neurons/NeuronBuilder.ts";
+
+export class GraphCircuitBuilder<
+  TNeurons extends Record<string, NeuronBuilder<any>> = {},
+> {
+  #state?: StateDefinition;
+  #neurons: Record<string, NeuronBuilder<any>> = {};
+  #edges: Record<string, EaCGraphCircuitEdgeLike> = {};
+
+  state(state: StateDefinition): this {
+    this.#state = state;
+    return this;
+  }
+
+  neuron<
+    K extends string,
+    N extends NeuronBuilder<any> & { id: K },
+  >(builder: N): GraphCircuitBuilder<TNeurons & { [P in K]: N }> {
+    this.#neurons[builder.id] = builder;
+    return this as unknown as GraphCircuitBuilder<
+      TNeurons & { [P in K]: N }
+    >;
+  }
+
+  edge<From extends keyof TNeurons>(from: TNeurons[From]) {
+    const fromId = from.id;
+    return {
+      to: <
+        Target extends
+          | TNeurons[keyof TNeurons]
+          | TNeurons[keyof TNeurons][]
+          | Record<string, TNeurons[keyof TNeurons]>
+      >(
+        target: Target,
+        options?: Omit<EaCGraphCircuitEdge, "Node">,
+      ): GraphCircuitBuilder<TNeurons> => {
+        let node: string | string[] | Record<string, string>;
+        if (Array.isArray(target)) {
+          node = target.map((t) => t.id);
+        } else if ("id" in target) {
+          node = target.id;
+        } else {
+          node = Object.fromEntries(
+            Object.entries(target).map(([k, v]) => [k, v.id]),
+          );
+        }
+
+        let edge: EaCGraphCircuitEdgeLike;
+        if (options || (typeof node === "object" && !Array.isArray(node))) {
+          edge = { Node: node, ...options } as EaCGraphCircuitEdge;
+        } else {
+          edge = node;
+        }
+
+        this.#edges[fromId] = edge;
+        return this;
+      },
+    };
+  }
+
+  build(): EaCGraphCircuitDetails {
+    const neurons: Record<string, unknown> = {};
+    for (const key in this.#neurons) {
+      Object.assign(neurons, this.#neurons[key].build());
+    }
+
+    return {
+      Type: "Graph",
+      Edges: this.#edges,
+      State: this.#state,
+      Neurons: neurons,
+    } as EaCGraphCircuitDetails;
+  }
+}

--- a/src/fluent/circuits/LinearCircuitBuilder.ts
+++ b/src/fluent/circuits/LinearCircuitBuilder.ts
@@ -1,0 +1,51 @@
+import { EaCLinearCircuitDetails } from "../../eac/EaCLinearCircuitDetails.ts";
+import { NeuronBuilder } from "./neurons/NeuronBuilder.ts";
+
+export class LinearCircuitBuilder<
+  TNeurons extends Record<string, NeuronBuilder<any>> = {},
+> {
+  #neurons: Record<string, NeuronBuilder<any>> = {};
+  #sequence: string[] = [];
+
+  neuron<
+    K extends string,
+    N extends NeuronBuilder<any> & { id: K },
+  >(builder: N): LinearCircuitBuilder<TNeurons & { [P in K]: N }> {
+    this.#neurons[builder.id] = builder;
+    return this as unknown as LinearCircuitBuilder<
+      TNeurons & { [P in K]: N }
+    >;
+  }
+
+  chain<
+    A extends TNeurons[keyof TNeurons],
+    B extends TNeurons[keyof TNeurons],
+    Rest extends TNeurons[keyof TNeurons][] = [],
+  >(...nodes: [A, B, ...Rest]): this {
+    this.#sequence = nodes.map((n) => n.id);
+    return this;
+  }
+
+  build(): EaCLinearCircuitDetails {
+    const neurons: Record<string, any> = {};
+    for (const key in this.#neurons) {
+      Object.assign(neurons, this.#neurons[key].build());
+    }
+
+    if (this.#sequence.length) {
+      neurons[""] = this.#sequence[0];
+      for (let i = 0; i < this.#sequence.length - 1; i++) {
+        const from = this.#sequence[i];
+        const to = this.#sequence[i + 1];
+        const detail = neurons[from] as Record<string, unknown>;
+        detail.Neurons = { "": to };
+      }
+    }
+
+    return {
+      Type: "Linear",
+      Neurons: neurons,
+    } as EaCLinearCircuitDetails;
+  }
+}
+

--- a/src/fluent/circuits/_exports.ts
+++ b/src/fluent/circuits/_exports.ts
@@ -1,0 +1,3 @@
+export * from "./GraphCircuitBuilder.ts";
+export * from "./LinearCircuitBuilder.ts";
+export * from "./neurons/_exports.ts";

--- a/src/fluent/circuits/neurons/ChatPromptNeuronBuilder.ts
+++ b/src/fluent/circuits/neurons/ChatPromptNeuronBuilder.ts
@@ -1,0 +1,25 @@
+import { BaseMessagePromptTemplateLike } from "../../../src.deps.ts";
+import { EaCChatPromptNeuron } from "../../../eac/neurons/EaCChatPromptNeuron.ts";
+import { PersonalityId } from "../../resources/PersonalityBuilder.ts";
+import { NeuronBuilder } from "./NeuronBuilder.ts";
+
+export type ChatPromptNeuronOptions = {
+  instructions?: string[];
+  messages?: BaseMessagePromptTemplateLike[];
+  newMessages?: BaseMessagePromptTemplateLike[];
+  personality?: PersonalityId;
+  systemMessage?: string;
+};
+
+export class ChatPromptNeuronBuilder extends NeuronBuilder<EaCChatPromptNeuron> {
+  constructor(lookup: string, options: ChatPromptNeuronOptions = {}) {
+    super(lookup, {
+      Type: "ChatPrompt",
+      Instructions: options.instructions,
+      Messages: options.messages,
+      NewMessages: options.newMessages,
+      PersonalityLookup: options.personality,
+      SystemMessage: options.systemMessage,
+    });
+  }
+}

--- a/src/fluent/circuits/neurons/NeuronBuilder.ts
+++ b/src/fluent/circuits/neurons/NeuronBuilder.ts
@@ -1,0 +1,16 @@
+import { EaCNeuronLike } from "../../../eac/EaCNeuron.ts";
+
+export abstract class NeuronBuilder<TDetails extends EaCNeuronLike> {
+  public readonly id: string;
+
+  protected constructor(
+    protected readonly lookup: string,
+    protected readonly details: TDetails,
+  ) {
+    this.id = lookup;
+  }
+
+  build(): Record<string, TDetails> {
+    return { [this.lookup]: this.details };
+  }
+}

--- a/src/fluent/circuits/neurons/ToolNeuronBuilder.ts
+++ b/src/fluent/circuits/neurons/ToolNeuronBuilder.ts
@@ -1,0 +1,9 @@
+import { EaCToolNeuron } from "../../../eac/neurons/EaCToolNeuron.ts";
+import { ToolId } from "../../resources/ToolBuilder.ts";
+import { NeuronBuilder } from "./NeuronBuilder.ts";
+
+export class ToolNeuronBuilder extends NeuronBuilder<EaCToolNeuron> {
+  constructor(lookup: string, tool: ToolId) {
+    super(lookup, { Type: "Tool", ToolLookup: tool });
+  }
+}

--- a/src/fluent/circuits/neurons/_exports.ts
+++ b/src/fluent/circuits/neurons/_exports.ts
@@ -1,0 +1,3 @@
+export * from "./NeuronBuilder.ts";
+export * from "./ChatPromptNeuronBuilder.ts";
+export * from "./ToolNeuronBuilder.ts";

--- a/tests/fluent/graphs/graph-circuit-builder.tests.ts
+++ b/tests/fluent/graphs/graph-circuit-builder.tests.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from "../../tests.deps.ts";
+import {
+  ChatPromptNeuronBuilder,
+  GraphCircuitBuilder,
+  ToolNeuronBuilder,
+} from "../../../src/fluent/circuits/_exports.ts";
+import { PersonalityId } from "../../../src/fluent/resources/PersonalityBuilder.ts";
+import { ToolId } from "../../../src/fluent/resources/ToolBuilder.ts";
+
+Deno.test("GraphCircuitBuilder builds graph", () => {
+  const agent = new ChatPromptNeuronBuilder("agent", {
+    personality: "p" as PersonalityId,
+  });
+  const tool = new ToolNeuronBuilder("tool", "t" as ToolId);
+
+  const details = new GraphCircuitBuilder()
+    .neuron(agent)
+    .neuron(tool)
+    .edge(agent)
+    .to(tool)
+    .build();
+
+  assertEquals(Object.keys(details.Neurons ?? {}), ["agent", "tool"]);
+  assertEquals(details.Edges.agent, "tool");
+  assertEquals(details.Type, "Graph");
+});

--- a/tests/fluent/linear/linear-circuit-builder.tests.ts
+++ b/tests/fluent/linear/linear-circuit-builder.tests.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from "../../tests.deps.ts";
+import {
+  ChatPromptNeuronBuilder,
+  LinearCircuitBuilder,
+  ToolNeuronBuilder,
+} from "../../../src/fluent/circuits/_exports.ts";
+import { PersonalityId } from "../../../src/fluent/resources/PersonalityBuilder.ts";
+import { ToolId } from "../../../src/fluent/resources/ToolBuilder.ts";
+
+Deno.test("LinearCircuitBuilder builds linear flow", () => {
+  const agent = new ChatPromptNeuronBuilder("agent", {
+    personality: "p" as PersonalityId,
+  });
+  const tool = new ToolNeuronBuilder("tool", "t" as ToolId);
+
+  const details = new LinearCircuitBuilder()
+    .neuron(agent)
+    .neuron(tool)
+    .chain(agent, tool)
+    .build();
+
+  assertEquals(details.Neurons[""], "agent");
+  const agentDetails = details.Neurons["agent"] as { Neurons: Record<string, string> };
+  assertEquals(agentDetails.Neurons[""], "tool");
+  assertEquals(details.Type, "Linear");
+});


### PR DESCRIPTION
## Summary
- add LinearCircuitBuilder to create sequential neuron flows and output EaCLinearCircuitDetails
- export new LinearCircuitBuilder through fluent circuits index
- test LinearCircuitBuilder chaining neurons

## Testing
- `deno test tests/fluent/linear/linear-circuit-builder.tests.ts` *(fails: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: 403)*

------
https://chatgpt.com/codex/tasks/task_b_6896a27031a08326947abcac9cefaef4