### PR TITLE
feat: add typed lookup helpers

### DIFF
--- a/src/fluent/_exports.ts
+++ b/src/fluent/_exports.ts
@@ -2,3 +2,4 @@ export * from "./EaCFluentBuilder.ts";
 export * from "./EaCFluentBuilderProxy.ts";
 export * from "./state/_exports.ts";
 export * from "./circuits/_exports.ts";
+export * from "./lookups/_exports.ts";

--- a/src/fluent/lookups/_exports.ts
+++ b/src/fluent/lookups/_exports.ts
@@ -1,0 +1,1 @@
+export * from "./index.ts";

--- a/src/fluent/lookups/index.ts
+++ b/src/fluent/lookups/index.ts
@@ -1,0 +1,110 @@
+import { Brand } from "../resources/ResourceBuilder.ts";
+import { ChatHistoryId } from "../resources/ChatHistoryBuilder.ts";
+import { DocumentLoaderId } from "../resources/DocumentLoaderBuilder.ts";
+import { EmbeddingsId } from "../resources/EmbeddingsBuilder.ts";
+import { IndexerId } from "../resources/IndexerBuilder.ts";
+import { LLMId } from "../resources/LLMBuilder.ts";
+import { PersistenceId } from "../resources/PersistenceBuilder.ts";
+import { PersonalityId } from "../resources/PersonalityBuilder.ts";
+import { RetrieverId } from "../resources/RetrieverBuilder.ts";
+import { TextSplitterId } from "../resources/TextSplitterBuilder.ts";
+import { ToolId } from "../resources/ToolBuilder.ts";
+import { VectorStoreId } from "../resources/VectorStoreBuilder.ts";
+
+export type LookupToken<T extends string> = Brand<string, T>;
+
+function scoped<T extends string>(
+  lookup: string,
+  scope: string,
+): LookupToken<T> {
+  return `${scope}|${lookup}` as LookupToken<T>;
+}
+
+export type AILookupToken = LookupToken<"AI">;
+export function ai(lookup: string, scope: string): AILookupToken {
+  return scoped<"AI">(lookup, scope);
+}
+
+export type CircuitLookupToken = LookupToken<"Circuit">;
+export function circuit(lookup: string, scope: string): CircuitLookupToken {
+  return scoped<"Circuit">(lookup, scope);
+}
+
+export type ChatHistoryLookupToken = LookupToken<"ChatHistory">;
+export function chatHistory(
+  lookup: ChatHistoryId,
+  scope: string,
+): ChatHistoryLookupToken {
+  return scoped<"ChatHistory">(lookup, scope);
+}
+
+export type DocumentLoaderLookupToken = LookupToken<"DocumentLoader">;
+export function documentLoader(
+  lookup: DocumentLoaderId,
+  scope: string,
+): DocumentLoaderLookupToken {
+  return scoped<"DocumentLoader">(lookup, scope);
+}
+
+export type EmbeddingsLookupToken = LookupToken<"Embeddings">;
+export function embeddings(
+  lookup: EmbeddingsId,
+  scope: string,
+): EmbeddingsLookupToken {
+  return scoped<"Embeddings">(lookup, scope);
+}
+
+export type IndexerLookupToken = LookupToken<"Indexer">;
+export function indexer(lookup: IndexerId, scope: string): IndexerLookupToken {
+  return scoped<"Indexer">(lookup, scope);
+}
+
+export type LLMLookupToken = LookupToken<"LLM">;
+export function llm(lookup: LLMId, scope: string): LLMLookupToken {
+  return scoped<"LLM">(lookup, scope);
+}
+
+export type PersistenceLookupToken = LookupToken<"Persistence">;
+export function persistence(
+  lookup: PersistenceId,
+  scope: string,
+): PersistenceLookupToken {
+  return scoped<"Persistence">(lookup, scope);
+}
+
+export type PersonalityLookupToken = LookupToken<"Personality">;
+export function personality(
+  lookup: PersonalityId,
+  scope: string,
+): PersonalityLookupToken {
+  return scoped<"Personality">(lookup, scope);
+}
+
+export type RetrieverLookupToken = LookupToken<"Retriever">;
+export function retriever(
+  lookup: RetrieverId,
+  scope: string,
+): RetrieverLookupToken {
+  return scoped<"Retriever">(lookup, scope);
+}
+
+export type TextSplitterLookupToken = LookupToken<"TextSplitter">;
+export function textSplitter(
+  lookup: TextSplitterId,
+  scope: string,
+): TextSplitterLookupToken {
+  return scoped<"TextSplitter">(lookup, scope);
+}
+
+export type ToolLookupToken = LookupToken<"Tool">;
+export function tool(lookup: ToolId, scope: string): ToolLookupToken {
+  return scoped<"Tool">(lookup, scope);
+}
+
+export type VectorStoreLookupToken = LookupToken<"VectorStore">;
+export function vectorStore(
+  lookup: VectorStoreId,
+  scope: string,
+): VectorStoreLookupToken {
+  return scoped<"VectorStore">(lookup, scope);
+}

--- a/src/plugins/FathymSynapticPlugin.ts
+++ b/src/plugins/FathymSynapticPlugin.ts
@@ -127,6 +127,21 @@ import {
   EaCSchemaDocumentLoaderDetails,
   isEaCSchemaDocumentLoaderDetails,
 } from "../eac/EaCSchemaDocumentLoaderDetails.ts";
+import {
+  ai as aiToken,
+  chatHistory as chatHistoryToken,
+  circuit as circuitToken,
+  documentLoader as documentLoaderToken,
+  embeddings as embeddingsToken,
+  indexer as indexerToken,
+  llm as llmToken,
+  persistence as persistenceToken,
+  personality as personalityToken,
+  retriever as retrieverToken,
+  textSplitter as textSplitterToken,
+  tool as toolToken,
+  vectorStore as vectorStoreToken,
+} from "../fluent/lookups/index.ts";
 
 export default class FathymSynapticPlugin implements EaCRuntimePlugin {
   protected dfsHandlerResolver: DFSFileHandlerResolver | undefined;
@@ -242,7 +257,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
 
             const ctx: CircuitContext = {
               AIaCLookup(lookup, scope) {
-                return `${scope ?? circuitLookup}|${lookup}`;
+                return aiToken(lookup, scope ?? circuitLookup);
               },
               CircuitLookup: circuitLookup,
               EaC: eac,
@@ -328,7 +343,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${chatHistoryLookup}`,
+              Name: chatHistoryToken(chatHistoryLookup, aiLookup),
               Type: ioc.Symbol("ChatHistory"),
             },
           );
@@ -387,11 +402,13 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             () => {
               return new RemoteRunnable({
                 url: new URL(circuitLookup, remoteCircuitUrl).href,
-              }).withConfig({ runName: `${remoteLookup}|${circuitLookup}` });
+              }).withConfig({
+                runName: circuitToken(circuitLookup, remoteLookup),
+              });
             },
             {
               Lazy: false,
-              Name: `${remoteLookup}|${circuitLookup}`,
+              Name: circuitToken(circuitLookup, remoteLookup),
               Type: ioc.Symbol("Circuit"),
             },
           );
@@ -490,7 +507,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
               }),
             {
               Lazy: false,
-              Name: `${aiLookup}|${embeddingsLookup}`,
+              Name: embeddingsToken(embeddingsLookup, aiLookup),
               Type: ioc.Symbol(Embeddings.name),
             },
           );
@@ -524,7 +541,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
               }),
             {
               Lazy: false,
-              Name: `${aiLookup}|${indexerLookup}`,
+              Name: indexerToken(indexerLookup, aiLookup),
               Type: ioc.Symbol("RecordManager"),
             },
           );
@@ -584,7 +601,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${llmLookup}`,
+              Name: llmToken(llmLookup, aiLookup),
               Type: ioc.Symbol(BaseLanguageModel.name),
             },
           );
@@ -619,7 +636,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${llmLookup}`,
+              Name: llmToken(llmLookup, aiLookup),
               Type: ioc.Symbol(BaseLanguageModel.name),
             },
           );
@@ -673,7 +690,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
               }),
             {
               Lazy: false,
-              Name: `${aiLookup}|${llmLookup}`,
+              Name: llmToken(llmLookup, aiLookup),
               Type: ioc.Symbol(BaseLanguageModel.name),
             },
           );
@@ -703,7 +720,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
 
           ioc.Register(() => new CheerioWebBaseLoader(details.URL), {
             Lazy: false,
-            Name: `${aiLookup}|${loaderLookup}`,
+            Name: documentLoaderToken(loaderLookup, aiLookup),
             Type: ioc.Symbol("DocumentLoader"),
           });
         } else if (isEaCDFSDocumentLoaderDetails(loader.Details)) {
@@ -774,7 +791,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${loaderLookup}`,
+              Name: documentLoaderToken(loaderLookup, aiLookup),
               Type: ioc.Symbol("DocumentLoader"),
             },
           );
@@ -804,7 +821,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${loaderLookup}`,
+              Name: documentLoaderToken(loaderLookup, aiLookup),
               Type: ioc.Symbol("DocumentLoader"),
             },
           );
@@ -848,7 +865,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${loaderLookup}`,
+              Name: documentLoaderToken(loaderLookup, aiLookup),
               Type: ioc.Symbol("DocumentLoader"),
             },
           );
@@ -876,7 +893,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
         if (isEaCMemorySaverPersistenceDetails(details)) {
           ioc.Register(() => new MemorySaver(), {
             Lazy: false,
-            Name: `${aiLookup}|${persistenceLookup}`,
+            Name: persistenceToken(persistenceLookup, aiLookup),
             Type: ioc.Symbol("Persistence"),
           });
         } else if (isEaCDenoKVSaverPersistenceDetails(details)) {
@@ -892,7 +909,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${persistenceLookup}`,
+              Name: persistenceToken(persistenceLookup, aiLookup),
               Type: ioc.Symbol("Persistence"),
             },
           );
@@ -959,7 +976,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
 
         ioc.Register(() => resultDetails, {
           Lazy: false,
-          Name: `${aiLookup}|${personalityLookup}`,
+          Name: personalityToken(personalityLookup, aiLookup),
           Type: ioc.Symbol("Personality"),
         });
       });
@@ -989,7 +1006,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
 
             await ioc.Register(() => vectorStore.asRetriever(), {
               Lazy: false,
-              Name: `${aiLookup}|${retrieverLookup}`,
+              Name: retrieverToken(retrieverLookup, aiLookup),
               Type: ioc.Symbol("Retriever"),
             });
 
@@ -1049,7 +1066,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
 
           ioc.Register(() => textSplitter, {
             Lazy: false,
-            Name: `${aiLookup}|${textSplitterLookup}`,
+            Name: textSplitterToken(textSplitterLookup, aiLookup),
             Type: ioc.Symbol(TextSplitter.name),
           });
         }
@@ -1080,7 +1097,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${toolLookup}`,
+              Name: toolToken(toolLookup, aiLookup),
               Type: ioc.Symbol("Tool"),
             },
           );
@@ -1093,7 +1110,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${toolLookup}`,
+              Name: toolToken(toolLookup, aiLookup),
               Type: ioc.Symbol("Tool"),
             },
           );
@@ -1115,7 +1132,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${toolLookup}`,
+              Name: toolToken(toolLookup, aiLookup),
               Type: ioc.Symbol("Tool"),
             },
           );
@@ -1159,7 +1176,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${toolLookup}`,
+              Name: toolToken(toolLookup, aiLookup),
               Type: ioc.Symbol("Tool"),
             },
           );
@@ -1174,7 +1191,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
             },
             {
               Lazy: false,
-              Name: `${aiLookup}|${toolLookup}`,
+              Name: toolToken(toolLookup, aiLookup),
               Type: ioc.Symbol("Tool"),
             },
           );
@@ -1220,7 +1237,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
               },
               {
                 Lazy: false,
-                Name: `${aiLookup}|${vectorStoreLookup}`,
+                Name: vectorStoreToken(vectorStoreLookup, aiLookup),
                 Type: ioc.Symbol(VectorStore.name),
               },
             );
@@ -1235,14 +1252,14 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
                 }),
               {
                 Lazy: false,
-                Name: `${aiLookup}|${vectorStoreLookup}`,
+                Name: vectorStoreToken(vectorStoreLookup, aiLookup),
                 Type: ioc.Symbol(VectorStore.name),
               },
             );
           } else if (isEaCMemoryVectorStoreDetails(vectorStore.Details)) {
             ioc.Register(() => new MemoryVectorStore(embeddings), {
               Lazy: false,
-              Name: `${aiLookup}|${vectorStoreLookup}`,
+              Name: vectorStoreToken(vectorStoreLookup, aiLookup),
               Type: ioc.Symbol(VectorStore.name),
             });
           }


### PR DESCRIPTION
## Summary
- add scoped lookup helpers for AI and resources
- refactor FathymSynapticPlugin to use lookup helpers for consistent tokens

## Testing
- `deno lint src/fluent/lookups/index.ts src/fluent/lookups/_exports.ts src/fluent/_exports.ts src/plugins/FathymSynapticPlugin.ts`
- `deno fmt src/fluent/lookups/index.ts src/fluent/lookups/_exports.ts src/fluent/_exports.ts src/plugins/FathymSynapticPlugin.ts`
- `deno task test` *(fails: Failed loading https://registry.npmjs.org/preact for package "preact" - invalid peer certificate)*


------
https://chatgpt.com/codex/tasks/task_b_6896a6c3c504832686d6d91e8a292caf