### PR TITLE
docs: add fluent builders migration guide and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,12 @@ provides the tools and infrastructure you need to bring your ideas to life.
 
 Join us in redefining what bots can do. Welcome to the future of bot building
 with Synaptic.
+
+## Fluent Builder Examples
+
+Synaptic now includes fluent builders for defining circuits directly in
+TypeScript. Check out the [migration guide](docs/fluent/migration-guide.mdx) and
+the [fluent examples](examples/fluent/basic-chat.ts) to get started.
+
+Runtime packages under `*-synaptic-runtimes` also reference these examples to
+encourage adoption.

--- a/docs/fluent/migration-guide.mdx
+++ b/docs/fluent/migration-guide.mdx
@@ -1,0 +1,65 @@
+# Migrating to Fluent Builders
+
+Synaptic originally defined circuits using JSON structures. The new fluent builders offer a type-safe and composable way to declare circuits directly in TypeScript.
+
+## Basic Chat Example
+
+### Previous JSON Circuit
+
+```ts
+{
+  "Circuits": {
+    "basic-chat": {
+      "Details": {
+        "Type": "Linear",
+        "Neurons": {
+          "": [
+            "test-chat",
+            {
+              "NewMessages": [["human", "{input}"]]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Fluent Builder Version
+
+```ts
+import { Annotation, START, END } from "npm:@langchain/langgraph@0.2.56";
+import {
+  ChatPromptNeuronBuilder,
+  GraphCircuitBuilder,
+} from "../../src/fluent/circuits/_exports.ts";
+import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
+import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+
+const persona = new PersonalityBuilder("pirate", {
+  Instructions: ["Answer like a pirate"],
+});
+
+const state = buildState((s) =>
+  s.Field("messages", {
+    reducer: (x: string[], y: string[]) => x.concat(y),
+    default: () => [],
+  })
+);
+
+const agent = new ChatPromptNeuronBuilder("agent", {
+  personality: persona.id,
+  newMessages: [["human", "{input}"]],
+});
+
+const circuit = new GraphCircuitBuilder()
+  .state(state)
+  .neuron(agent)
+  .edge({ id: START } as any).to(agent)
+  .edge(agent).to(END)
+  .build();
+```
+
+The fluent version uses builders to define resources, state, and edges in a concise, expressive way. See the full example in [`examples/fluent/basic-chat.ts`](../../examples/fluent/basic-chat.ts).
+

--- a/examples/fluent/basic-chat.ts
+++ b/examples/fluent/basic-chat.ts
@@ -1,0 +1,50 @@
+import { Annotation, START, END } from "npm:@langchain/langgraph@0.2.56";
+import {
+  ChatPromptNeuronBuilder,
+  GraphCircuitBuilder,
+} from "../../src/fluent/circuits/_exports.ts";
+import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
+import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+
+// Define a personality resource that the chat prompt will use
+const piratePersona = new PersonalityBuilder("pirate", {
+  Instructions: ["Answer like a pirate"],
+});
+
+// Describe the circuit state: an accumulating list of messages
+const state = buildState((s) =>
+  s.Field("messages", {
+    reducer: (x: string[], y: string[]) => x.concat(y),
+    default: () => [],
+  })
+);
+
+// Build a chat prompt neuron that sends new human messages
+const agent = new ChatPromptNeuronBuilder("agent", {
+  personality: piratePersona.id,
+  newMessages: [["human", "{input}"]],
+});
+
+// Assemble the graph circuit with explicit edges
+const circuit = new GraphCircuitBuilder()
+  .state(state)
+  .neuron(agent)
+  // Start -> agent
+  .edge({ id: START } as any).to(agent)
+  // agent -> END
+  .edge(agent).to(END)
+  .build();
+
+// Export an EverythingAsCode fragment representing the circuit
+export const eac = {
+  AIs: {
+    example: {
+      Personalities: piratePersona.build(),
+    },
+  },
+  Circuits: {
+    "basic-chat": { Details: circuit },
+  },
+};
+
+console.log(JSON.stringify(eac, null, 2));

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,0 +1,6 @@
+# Synaptic Runtimes
+
+Runtime packages built on Synaptic can leverage the new fluent circuit builders.
+See the [fluent examples](../examples/fluent/basic-chat.ts) for a
+self-contained circuit and the [migration guide](../docs/fluent/migration-guide.mdx)
+to convert existing JSON circuits.


### PR DESCRIPTION
## Summary
- document migrating JSON circuits to fluent builders
- add a basic chat circuit using fluent builders
- link fluent examples from README and runtime docs

## Testing
- `deno fmt docs/fluent/migration-guide.mdx examples/fluent/basic-chat.ts README.md runtime/README.md` *(fails: command not found)*
- `curl -fsSL https://deno.land/x/install/install.sh | sh` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6896a951ca588326b5a944955f117694