### PR TITLE
docs: add fluent builder guides

### DIFF
--- a/docs/Overview.mdx
+++ b/docs/Overview.mdx
@@ -31,3 +31,27 @@ Building a bot can be a complex task. There are many moving parts, and managing 
 4. **Customizable Synapses Services**: The ability to create additional Synapses services means that you can tailor your bot to your specific needs. Whether you need to integrate with a specific database, automate a particular process, or perform a unique task, Synaptic gives you the tools to do so.
 
 By addressing these complexities, Synaptic makes it easier to build, manage, and improve bots. Whether you're looking to automate customer service, streamline business processes, or create a virtual assistant, Synaptic provides the tools and infrastructure you need to bring your ideas to life.
+
+## Fluent Builder Documentation
+
+- [Quick Start](./fluent/quick-start.mdx)
+- Builder reference:
+  - [ChatHistoryBuilder](./reference/ChatHistoryBuilder.mdx)
+  - [ChatPromptNeuronBuilder](./reference/ChatPromptNeuronBuilder.mdx)
+  - [DocumentLoaderBuilder](./reference/DocumentLoaderBuilder.mdx)
+  - [EmbeddingsBuilder](./reference/EmbeddingsBuilder.mdx)
+  - [GraphCircuitBuilder](./reference/GraphCircuitBuilder.mdx)
+  - [IndexerBuilder](./reference/IndexerBuilder.mdx)
+  - [InputBuilder](./reference/InputBuilder.mdx)
+  - [LLMBuilder](./reference/LLMBuilder.mdx)
+  - [LinearCircuitBuilder](./reference/LinearCircuitBuilder.mdx)
+  - [NeuronBuilder](./reference/NeuronBuilder.mdx)
+  - [PersistenceBuilder](./reference/PersistenceBuilder.mdx)
+  - [PersonalityBuilder](./reference/PersonalityBuilder.mdx)
+  - [ResourceBuilder](./reference/ResourceBuilder.mdx)
+  - [RetrieverBuilder](./reference/RetrieverBuilder.mdx)
+  - [StateBuilder](./reference/StateBuilder.mdx)
+  - [TextSplitterBuilder](./reference/TextSplitterBuilder.mdx)
+  - [ToolBuilder](./reference/ToolBuilder.mdx)
+  - [ToolNeuronBuilder](./reference/ToolNeuronBuilder.mdx)
+  - [VectorStoreBuilder](./reference/VectorStoreBuilder.mdx)

--- a/docs/fluent/migration-guide.mdx
+++ b/docs/fluent/migration-guide.mdx
@@ -63,3 +63,27 @@ const circuit = new GraphCircuitBuilder()
 
 The fluent version uses builders to define resources, state, and edges in a concise, expressive way. See the full example in [`examples/fluent/basic-chat.ts`](../../examples/fluent/basic-chat.ts).
 
+
+## Further Reading
+
+- [Fluent Quick Start](./quick-start.mdx)
+- Builder reference:
+  - [ChatHistoryBuilder](../reference/ChatHistoryBuilder.mdx)
+  - [ChatPromptNeuronBuilder](../reference/ChatPromptNeuronBuilder.mdx)
+  - [DocumentLoaderBuilder](../reference/DocumentLoaderBuilder.mdx)
+  - [EmbeddingsBuilder](../reference/EmbeddingsBuilder.mdx)
+  - [GraphCircuitBuilder](../reference/GraphCircuitBuilder.mdx)
+  - [IndexerBuilder](../reference/IndexerBuilder.mdx)
+  - [InputBuilder](../reference/InputBuilder.mdx)
+  - [LLMBuilder](../reference/LLMBuilder.mdx)
+  - [LinearCircuitBuilder](../reference/LinearCircuitBuilder.mdx)
+  - [NeuronBuilder](../reference/NeuronBuilder.mdx)
+  - [PersistenceBuilder](../reference/PersistenceBuilder.mdx)
+  - [PersonalityBuilder](../reference/PersonalityBuilder.mdx)
+  - [ResourceBuilder](../reference/ResourceBuilder.mdx)
+  - [RetrieverBuilder](../reference/RetrieverBuilder.mdx)
+  - [StateBuilder](../reference/StateBuilder.mdx)
+  - [TextSplitterBuilder](../reference/TextSplitterBuilder.mdx)
+  - [ToolBuilder](../reference/ToolBuilder.mdx)
+  - [ToolNeuronBuilder](../reference/ToolNeuronBuilder.mdx)
+  - [VectorStoreBuilder](../reference/VectorStoreBuilder.mdx)

--- a/docs/fluent/quick-start.mdx
+++ b/docs/fluent/quick-start.mdx
@@ -1,0 +1,65 @@
+---
+title: Fluent Quick Start
+---
+
+# Fluent Builder Quick Start
+
+The fluent builders provide a type-safe way to construct Synaptic resources, state and circuits directly in TypeScript.
+
+The full stack involves:
+
+1. **Resource builders** – define shared assets like personalities.
+2. **State builder** – describe the shape of circuit state.
+3. **Neuron builders** – create nodes that perform work.
+4. **Circuit builders** – wire neurons together into a runnable graph.
+
+## Minimal runnable example
+
+The snippet below assembles a simple chat circuit and exports an EverythingAsCode fragment that can be executed with Deno.
+
+```ts
+import { Annotation, START, END } from "npm:@langchain/langgraph@0.2.56";
+import { GraphCircuitBuilder, ChatPromptNeuronBuilder } from "../../src/fluent/circuits/_exports.ts";
+import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
+import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+
+const pirate = new PersonalityBuilder("pirate", {
+  Instructions: ["Answer like a pirate"],
+});
+
+const state = buildState((s) =>
+  s.Field("messages", {
+    reducer: (x: string[], y: string[]) => x.concat(y),
+    default: () => [],
+  })
+);
+
+const agent = new ChatPromptNeuronBuilder("agent", {
+  personality: pirate.id,
+  newMessages: [["human", "{input}"]],
+});
+
+const circuit = new GraphCircuitBuilder()
+  .state(state)
+  .neuron(agent)
+  .edge({ id: START } as any).to(agent)
+  .edge(agent).to(END)
+  .build();
+
+export const eac = {
+  AIs: {
+    example: { Personalities: pirate.build() },
+  },
+  Circuits: {
+    "basic-chat": { Details: circuit },
+  },
+};
+```
+
+Run it with:
+
+```bash
+deno run -A examples/fluent/basic-chat.ts
+```
+
+The fluent builders let you extend this pattern with additional resources, neurons and complex graph topologies.

--- a/docs/reference/ChatHistoryBuilder.mdx
+++ b/docs/reference/ChatHistoryBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: ChatHistoryBuilder
+---
+
+# ChatHistoryBuilder
+
+Builds `ChatHistory` resources for EverythingAsCode.
+
+## Constructor
+
+`new ChatHistoryBuilder(lookup: string, details: EaCChatHistoryDetails)`
+
+- **lookup** – unique identifier for the chat history resource.
+- **details** – `EaCChatHistoryDetails` options describing the history store.
+
+## Methods
+
+- `build(): Record<string, EaCChatHistoryAsCode>` – export the resource in EverythingAsCode format.
+
+## Example
+
+```ts
+const history = new ChatHistoryBuilder("mem", { /* EaCChatHistoryDetails */ });
+const eac = history.build();
+```

--- a/docs/reference/ChatPromptNeuronBuilder.mdx
+++ b/docs/reference/ChatPromptNeuronBuilder.mdx
@@ -1,0 +1,32 @@
+---
+title: ChatPromptNeuronBuilder
+---
+
+# ChatPromptNeuronBuilder
+
+Builds a neuron that sends chat prompts to an LLM.
+
+## Constructor
+
+`new ChatPromptNeuronBuilder(id: string, options?: ChatPromptNeuronOptions)`
+
+`ChatPromptNeuronOptions`:
+- `instructions?: string[]`
+- `messages?: BaseMessagePromptTemplateLike[]`
+- `newMessages?: BaseMessagePromptTemplateLike[]`
+- `personality?: PersonalityId`
+- `systemMessage?: string`
+
+## Methods
+
+- `build(): Record<string, EaCChatPromptNeuron>` – EverythingAsCode fragment for the neuron.
+
+## Example
+
+```ts
+const agent = new ChatPromptNeuronBuilder("agent", {
+  personality: persona.id,
+  newMessages: [["human", "{input}"]],
+});
+const neuron = agent.build();
+```

--- a/docs/reference/DocumentLoaderBuilder.mdx
+++ b/docs/reference/DocumentLoaderBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: DocumentLoaderBuilder
+---
+
+# DocumentLoaderBuilder
+
+Defines `DocumentLoader` resources for loading raw documents.
+
+## Constructor
+
+`new DocumentLoaderBuilder(lookup: string, details: EaCDocumentLoaderDetails)`
+
+- **lookup** – unique identifier.
+- **details** – `EaCDocumentLoaderDetails` with loader configuration.
+
+## Methods
+
+- `build(): Record<string, EaCDocumentLoaderAsCode>` – EverythingAsCode output.
+
+## Example
+
+```ts
+const loader = new DocumentLoaderBuilder("fs", { /* EaCDocumentLoaderDetails */ });
+const eac = loader.build();
+```

--- a/docs/reference/EmbeddingsBuilder.mdx
+++ b/docs/reference/EmbeddingsBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: EmbeddingsBuilder
+---
+
+# EmbeddingsBuilder
+
+Creates `Embeddings` resources used for vector generation.
+
+## Constructor
+
+`new EmbeddingsBuilder(lookup: string, details: EaCEmbeddingsDetails)`
+
+- **lookup** – unique identifier.
+- **details** – `EaCEmbeddingsDetails` options for the embeddings model.
+
+## Methods
+
+- `build(): Record<string, EaCEmbeddingsAsCode>` – produce EverythingAsCode output.
+
+## Example
+
+```ts
+const emb = new EmbeddingsBuilder("openai", { /* EaCEmbeddingsDetails */ });
+const eac = emb.build();
+```

--- a/docs/reference/GraphCircuitBuilder.mdx
+++ b/docs/reference/GraphCircuitBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: GraphCircuitBuilder
+---
+
+# GraphCircuitBuilder
+
+Assembles neurons into an arbitrary graph circuit.
+
+## Methods
+
+- `state(state: StateDefinition): this` – attach a state schema.
+- `neuron(builder: NeuronBuilder): this` – register a neuron by its id.
+- `edge(from).to(target, options?)` – connect neurons with optional `EaCGraphCircuitEdge` options.
+- `build(): EaCGraphCircuitDetails` – create the circuit definition.
+
+## Example
+
+```ts
+const circuit = new GraphCircuitBuilder()
+  .state(state)
+  .neuron(agent)
+  .edge({ id: START } as any).to(agent)
+  .edge(agent).to(END)
+  .build();
+```

--- a/docs/reference/IndexerBuilder.mdx
+++ b/docs/reference/IndexerBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: IndexerBuilder
+---
+
+# IndexerBuilder
+
+Defines `Indexer` resources for ingesting documents.
+
+## Constructor
+
+`new IndexerBuilder(lookup: string, details: EaCIndexerDetails)`
+
+- **lookup** – identifier for the indexer.
+- **details** – `EaCIndexerDetails` describing the indexing strategy.
+
+## Methods
+
+- `build(): Record<string, EaCIndexerAsCode>` – export EverythingAsCode fragment.
+
+## Example
+
+```ts
+const indexer = new IndexerBuilder("basic", { /* EaCIndexerDetails */ });
+const eac = indexer.build();
+```

--- a/docs/reference/InputBuilder.mdx
+++ b/docs/reference/InputBuilder.mdx
@@ -1,0 +1,22 @@
+---
+title: InputBuilder
+---
+
+# InputBuilder
+
+Utility that derives an input schema from circuit state and additional fields.
+
+## Signature
+
+`InputBuilder<TStateSchema, TAdditional>(state: TStateSchema, additional: ZodRawShape)`
+
+Returns an object with:
+- `Schema` – a Zod schema for the combined input.
+- `Type` – inferred TypeScript type.
+
+## Example
+
+```ts
+const input = InputBuilder(state, { query: z.string() });
+// input.Schema is a Zod schema and input.Type is the inferred type
+```

--- a/docs/reference/LLMBuilder.mdx
+++ b/docs/reference/LLMBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: LLMBuilder
+---
+
+# LLMBuilder
+
+Constructs Large Language Model resources.
+
+## Constructor
+
+`new LLMBuilder(lookup: string, details: EaCLLMDetails)`
+
+- **lookup** – identifier for the LLM.
+- **details** – `EaCLLMDetails` with provider and model options.
+
+## Methods
+
+- `build(): Record<string, EaCLLMAsCode>` – output EverythingAsCode fragment.
+
+## Example
+
+```ts
+const llm = new LLMBuilder("openai", { /* EaCLLMDetails */ });
+const eac = llm.build();
+```

--- a/docs/reference/LinearCircuitBuilder.mdx
+++ b/docs/reference/LinearCircuitBuilder.mdx
@@ -1,0 +1,23 @@
+---
+title: LinearCircuitBuilder
+---
+
+# LinearCircuitBuilder
+
+Creates simple linear sequences of neurons.
+
+## Methods
+
+- `neuron(builder: NeuronBuilder): this` – add a neuron to the circuit.
+- `chain(...nodes: NeuronBuilder[])` – declare the ordered sequence to execute.
+- `build(): EaCLinearCircuitDetails` – output the circuit definition.
+
+## Example
+
+```ts
+const circuit = new LinearCircuitBuilder()
+  .neuron(a)
+  .neuron(b)
+  .chain(a, b)
+  .build();
+```

--- a/docs/reference/NeuronBuilder.mdx
+++ b/docs/reference/NeuronBuilder.mdx
@@ -1,0 +1,28 @@
+---
+title: NeuronBuilder
+---
+
+# NeuronBuilder
+
+Abstract base for all neuron builders.
+
+## Constructor
+
+`protected constructor(lookup: string, details: EaCNeuronLike)`
+
+- **lookup** – neuron identifier.
+- **details** – configuration describing the neuron.
+
+## Methods
+
+- `build(): Record<string, EaCNeuronLike>` – EverythingAsCode fragment for the neuron.
+
+## Example
+
+```ts
+class MyNeuron extends NeuronBuilder<MyDetails> {
+  constructor(id: string, details: MyDetails) {
+    super(id, details);
+  }
+}
+```

--- a/docs/reference/PersistenceBuilder.mdx
+++ b/docs/reference/PersistenceBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: PersistenceBuilder
+---
+
+# PersistenceBuilder
+
+Creates `Persistence` resources for storing state.
+
+## Constructor
+
+`new PersistenceBuilder(lookup: string, details: EaCPersistenceDetails)`
+
+- **lookup** – identifier for the persistence backend.
+- **details** – `EaCPersistenceDetails` describing storage options.
+
+## Methods
+
+- `build(): Record<string, EaCPersistenceAsCode>` – build EverythingAsCode fragment.
+
+## Example
+
+```ts
+const persistence = new PersistenceBuilder("kv", { /* EaCPersistenceDetails */ });
+const eac = persistence.build();
+```

--- a/docs/reference/PersonalityBuilder.mdx
+++ b/docs/reference/PersonalityBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: PersonalityBuilder
+---
+
+# PersonalityBuilder
+
+Creates `Personality` resources that influence agent behavior.
+
+## Constructor
+
+`new PersonalityBuilder(lookup: string, details: EaCPersonalityDetails)`
+
+- **lookup** – identifier for the personality.
+- **details** – `EaCPersonalityDetails` such as instructions.
+
+## Methods
+
+- `build(): Record<string, EaCPersonalityAsCode>` – EverythingAsCode output.
+
+## Example
+
+```ts
+const persona = new PersonalityBuilder("pirate", { Instructions: ["Talk like a pirate"] });
+const eac = persona.build();
+```

--- a/docs/reference/ResourceBuilder.mdx
+++ b/docs/reference/ResourceBuilder.mdx
@@ -1,0 +1,35 @@
+---
+title: ResourceBuilder
+---
+
+# ResourceBuilder
+
+Generic base class for creating EverythingAsCode resource fragments.
+
+## Constructor
+
+`protected constructor(lookup: string, details: TDetails)`
+
+Creates a builder with an identifier and resource `details`.
+
+## Properties
+
+- `id: Brand<string, TBrand>` – branded identifier for the resource.
+
+## Methods
+
+- `protected buildAs(): Record<string, TAsCode>` – helper that produces the EverythingAsCode representation used by subclasses.
+
+## Example
+
+```ts
+class MyBuilder extends ResourceBuilder<MyDetails, MyAsCode, "My"> {
+  constructor(lookup: string, details: MyDetails) {
+    super(lookup, details);
+  }
+
+  build() {
+    return this.buildAs();
+  }
+}
+```

--- a/docs/reference/RetrieverBuilder.mdx
+++ b/docs/reference/RetrieverBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: RetrieverBuilder
+---
+
+# RetrieverBuilder
+
+Creates `Retriever` resources for fetching relevant documents.
+
+## Constructor
+
+`new RetrieverBuilder(lookup: string, details: EaCRetrieverDetails)`
+
+- **lookup** – unique identifier.
+- **details** – `EaCRetrieverDetails` configuring the retriever.
+
+## Methods
+
+- `build(): Record<string, EaCRetrieverAsCode>` – EverythingAsCode fragment.
+
+## Example
+
+```ts
+const retriever = new RetrieverBuilder("vec", { /* EaCRetrieverDetails */ });
+const eac = retriever.build();
+```

--- a/docs/reference/StateBuilder.mdx
+++ b/docs/reference/StateBuilder.mdx
@@ -1,0 +1,27 @@
+---
+title: StateBuilder
+---
+
+# StateBuilder
+
+Describes the state schema for a circuit.
+
+## Methods
+
+- `Field(name, { reducer?, default? }): this` – add a state field with optional reducer and default value.
+- `Build(): Record<string, Annotation>` – finalize the state definition.
+
+### Helper
+
+`buildState(builder: (sb: StateBuilder) => StateBuilder): Record<string, Annotation>` wraps the builder pattern.
+
+## Example
+
+```ts
+const state = buildState((s) =>
+  s.Field("messages", {
+    reducer: (x: string[], y: string[]) => x.concat(y),
+    default: () => [],
+  })
+);
+```

--- a/docs/reference/TextSplitterBuilder.mdx
+++ b/docs/reference/TextSplitterBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: TextSplitterBuilder
+---
+
+# TextSplitterBuilder
+
+Creates `TextSplitter` resources for breaking text into chunks.
+
+## Constructor
+
+`new TextSplitterBuilder(lookup: string, details: EaCTextSplitterDetails)`
+
+- **lookup** – identifier for the splitter.
+- **details** – `EaCTextSplitterDetails` with splitting options.
+
+## Methods
+
+- `build(): Record<string, EaCTextSplitterAsCode>` – EverythingAsCode output.
+
+## Example
+
+```ts
+const splitter = new TextSplitterBuilder("chars", { /* EaCTextSplitterDetails */ });
+const eac = splitter.build();
+```

--- a/docs/reference/ToolBuilder.mdx
+++ b/docs/reference/ToolBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: ToolBuilder
+---
+
+# ToolBuilder
+
+Defines `Tool` resources that can be invoked by neurons.
+
+## Constructor
+
+`new ToolBuilder(lookup: string, details: EaCToolDetails)`
+
+- **lookup** – identifier for the tool.
+- **details** – `EaCToolDetails` describing the implementation.
+
+## Methods
+
+- `build(): Record<string, EaCToolAsCode>` – EverythingAsCode fragment.
+
+## Example
+
+```ts
+const tool = new ToolBuilder("search", { /* EaCToolDetails */ });
+const eac = tool.build();
+```

--- a/docs/reference/ToolNeuronBuilder.mdx
+++ b/docs/reference/ToolNeuronBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: ToolNeuronBuilder
+---
+
+# ToolNeuronBuilder
+
+Creates a neuron that invokes a registered tool.
+
+## Constructor
+
+`new ToolNeuronBuilder(id: string, tool: ToolId)`
+
+- **id** – neuron identifier.
+- **tool** – `ToolId` to execute.
+
+## Methods
+
+- `build(): Record<string, EaCToolNeuron>` – EverythingAsCode fragment.
+
+## Example
+
+```ts
+const neuron = new ToolNeuronBuilder("call-search", tool.id);
+const eac = neuron.build();
+```

--- a/docs/reference/VectorStoreBuilder.mdx
+++ b/docs/reference/VectorStoreBuilder.mdx
@@ -1,0 +1,25 @@
+---
+title: VectorStoreBuilder
+---
+
+# VectorStoreBuilder
+
+Creates `VectorStore` resources for embedding storage.
+
+## Constructor
+
+`new VectorStoreBuilder(lookup: string, details: EaCVectorStoreDetails)`
+
+- **lookup** – identifier for the store.
+- **details** – `EaCVectorStoreDetails` describing persistence options.
+
+## Methods
+
+- `build(): Record<string, EaCVectorStoreAsCode>` – EverythingAsCode fragment.
+
+## Example
+
+```ts
+const store = new VectorStoreBuilder("mem", { /* EaCVectorStoreDetails */ });
+const eac = store.build();
+```


### PR DESCRIPTION
## Summary
- add fluent builder quick start with runnable example
- generate reference docs for each builder type
- link quick start and references from overview and migration guide

## Testing
- `npx -y deno fmt docs/Overview.mdx`
- `npx -y deno lint`
- `npx -y deno test`

------
https://chatgpt.com/codex/tasks/task_b_6896ad1c59b4832696b7762982291607