### PR TITLE
feat: add user requirement and workflow fluent examples

### DIFF
--- a/docs/fluent/migration-guide.mdx
+++ b/docs/fluent/migration-guide.mdx
@@ -112,6 +112,22 @@ import {
 } from "../../src/fluent/circuits/_exports.ts";
 import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
 import { ToolBuilder } from "../../src/fluent/resources/ToolBuilder.ts";
+import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+import { InputBuilder } from "../../src/fluent/state/InputBuilder.ts";
+
+const state = buildState((s) =>
+  s.Field("text", {
+    reducer: (_x, y: string) => y,
+    default: () => "",
+  }).Field("requirement", {
+    reducer: (_x, y: string) => y,
+    default: () => "",
+  })
+);
+
+const input = InputBuilder(state, {
+  text: z.string(),
+});
 
 const persona = new PersonalityBuilder("analyst", {
   Instructions: ["Extract the user's requirement and summarize it."],
@@ -122,7 +138,7 @@ const extractTool = new ToolBuilder("extract", {
   Name: "extract",
   Description: "Extract user requirements from text",
   Schema: z.object({ text: z.string() }),
-  Action: async (input: { text: string }) => `User requires: ${input.text}`,
+  Action: ({ text }: { text: string }) => `User requires: ${text}`,
 });
 
 const agent = new ChatPromptNeuronBuilder("agent", {
@@ -139,7 +155,7 @@ const circuit = new LinearCircuitBuilder()
   .build();
 ```
 
-Using `persona.id` and `extractTool.id` removes fragile string lookups from the JSON version. See the full example in [`examples/fluent/linear-circuit-with-tools.ts`](../../examples/fluent/linear-circuit-with-tools.ts).
+Using `buildState` and `InputBuilder` provides typed state and inputs, while `persona.id` and `extractTool.id` remove fragile string lookups from the JSON version. See the full example in [`examples/fluent/user-requirement-extract.ts`](../../examples/fluent/user-requirement-extract.ts).
 
 
 ## Graph circuit with branching
@@ -213,6 +229,72 @@ const circuit = new GraphCircuitBuilder()
 ```
 
 Edges now reference builder instances directly instead of string IDs, eliminating string lookups. See [`examples/fluent/graph-circuit-with-branching.ts`](../../examples/fluent/graph-circuit-with-branching.ts) for the complete example.
+
+## Thinky UR Workflows graph circuit
+
+This example mirrors the Thinky user requirement workflows circuit using resource builders and typed edges.
+
+```ts
+import { START, END } from "npm:@langchain/langgraph@0.2.56";
+import { z } from "npm:zod";
+import {
+  ChatPromptNeuronBuilder,
+  GraphCircuitBuilder,
+  ToolNeuronBuilder,
+} from "../../src/fluent/circuits/_exports.ts";
+import {
+  LLMBuilder,
+  PersonalityBuilder,
+  ToolBuilder,
+} from "../../src/fluent/resources/index.ts";
+import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+
+const llm = new LLMBuilder("thinky-llm", {
+  Type: "OpenAI",
+  ModelName: "gpt-4o-mini",
+  APIKey: "fake",
+});
+
+const persona = new PersonalityBuilder("workflow-analyst", {
+  Instructions: ["Assist with requirement workflows."],
+});
+
+  const searchTool = new ToolBuilder("search", {
+    Type: "Dynamic",
+    Name: "search",
+    Description: "Search existing requirements",
+    Schema: z.object({ query: z.string() }),
+    Action: ({ query }: { query: string }) => `results for ${query}`,
+  });
+
+const state = buildState((s) =>
+  s.Field("messages", {
+    reducer: (x: string[], y: string[]) => x.concat(y),
+    default: () => [],
+  })
+);
+
+const agent = new ChatPromptNeuronBuilder("agent", {
+  personality: persona.id,
+  newMessages: [["human", "{input}"]],
+});
+
+const tool = new ToolNeuronBuilder("search-tool", searchTool.id);
+
+  const circuit = new GraphCircuitBuilder()
+    .state(state)
+    .neuron(agent)
+    .neuron(tool)
+    .edge({ id: START } as { id: typeof START }).to(agent)
+    .edge(agent).to({ [END]: END, tools: tool }, {
+    Condition: (s: { messages: string[] }) =>
+      s.messages.at(-1)?.includes("search") ? "tools" : END,
+  })
+  .edge(tool).to(agent)
+  .build();
+```
+
+See [`examples/fluent/ur-workflows.ts`](../../examples/fluent/ur-workflows.ts) for the full example.
 
 ## Further Reading
 

--- a/examples/fluent/ur-workflows.ts
+++ b/examples/fluent/ur-workflows.ts
@@ -1,0 +1,79 @@
+import { END, START } from "npm:@langchain/langgraph@0.2.56";
+import { z } from "npm:zod";
+import {
+  ChatPromptNeuronBuilder,
+  GraphCircuitBuilder,
+  ToolNeuronBuilder,
+} from "../../src/fluent/circuits/_exports.ts";
+import {
+  LLMBuilder,
+  PersonalityBuilder,
+  ToolBuilder,
+} from "../../src/fluent/resources/index.ts";
+import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+
+// Define resources
+const llm = new LLMBuilder("thinky-llm", {
+  Type: "OpenAI",
+  ModelName: "gpt-4o-mini",
+  APIKey: "fake",
+});
+
+const persona = new PersonalityBuilder("workflow-analyst", {
+  Instructions: ["Assist with requirement workflows."],
+});
+
+const searchTool = new ToolBuilder("search", {
+  Type: "Dynamic",
+  Name: "search",
+  Description: "Search existing requirements",
+  Schema: z.object({ query: z.string() }),
+  Action: ({ query }: { query: string }) => `results for ${query}`,
+});
+
+// Circuit state
+const state = buildState((s) =>
+  s.Field("messages", {
+    reducer: (x: string[], y: string[]) => x.concat(y),
+    default: () => [],
+  })
+);
+
+// Build neurons
+const agent = new ChatPromptNeuronBuilder("agent", {
+  personality: persona.id,
+  newMessages: [["human", "{input}"]],
+});
+
+const tool = new ToolNeuronBuilder("search-tool", searchTool.id);
+
+// Assemble the graph circuit with typed edges
+const circuit = new GraphCircuitBuilder()
+  .state(state)
+  .neuron(agent)
+  .neuron(tool)
+  .edge({ id: START } as { id: typeof START }).to(agent)
+  .edge(agent).to({ [END]: END, tools: tool }, {
+    Condition: (s: { messages: string[] }) => {
+      const last = s.messages.at(-1) ?? "";
+      return last.includes("search") ? "tools" : END;
+    },
+  })
+  .edge(tool).to(agent)
+  .build();
+
+// Export EverythingAsCode fragment
+export const eac = {
+  AIs: {
+    example: {
+      LLMs: llm.build(),
+      Personalities: persona.build(),
+      Tools: searchTool.build(),
+    },
+  },
+  Circuits: {
+    "ur-workflows": { Details: circuit },
+  },
+};
+
+console.log(JSON.stringify(eac, null, 2));

--- a/examples/fluent/user-requirement-extract.ts
+++ b/examples/fluent/user-requirement-extract.ts
@@ -1,0 +1,70 @@
+import { z } from "npm:zod";
+import {
+  ChatPromptNeuronBuilder,
+  LinearCircuitBuilder,
+  ToolNeuronBuilder,
+} from "../../src/fluent/circuits/_exports.ts";
+import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
+import { ToolBuilder } from "../../src/fluent/resources/ToolBuilder.ts";
+import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+import { InputBuilder } from "../../src/fluent/state/InputBuilder.ts";
+
+// Define circuit state and typed input
+const state = buildState((s) =>
+  s.Field("text", {
+    reducer: (_x, y: string) => y,
+    default: () => "",
+  }).Field("requirement", {
+    reducer: (_x, y: string) => y,
+    default: () => "",
+  })
+);
+
+const input = InputBuilder(state, {
+  text: z.string(),
+});
+
+// Define resources used by the circuit
+const persona = new PersonalityBuilder("analyst", {
+  Instructions: ["Extract the user's requirement and summarize it."],
+});
+
+const extractTool = new ToolBuilder("extract", {
+  Type: "Dynamic",
+  Name: "extract",
+  Description: "Extract user requirements from text",
+  Schema: z.object({ text: z.string() }),
+  Action: ({ text }: { text: string }) => `User requires: ${text}`,
+});
+
+// Build neurons for the linear flow
+const agent = new ChatPromptNeuronBuilder("agent", {
+  personality: persona.id,
+  newMessages: [["human", "{text}"]],
+});
+
+const tool = new ToolNeuronBuilder("extract-tool", extractTool.id);
+
+// Assemble the linear circuit
+const circuit = new LinearCircuitBuilder()
+  .neuron(agent)
+  .neuron(tool)
+  .chain(agent, tool)
+  .build();
+
+// Export EverythingAsCode fragment and typed input
+export const eac = {
+  AIs: {
+    example: {
+      Personalities: persona.build(),
+      Tools: extractTool.build(),
+    },
+  },
+  Circuits: {
+    "user-requirement-extract": { Details: circuit },
+  },
+};
+
+export type UserRequirementInput = typeof input.Type;
+
+console.log(JSON.stringify(eac, null, 2));


### PR DESCRIPTION
## Summary
- add user requirement extraction linear circuit using state and input builders
- add Thinky UR Workflows graph circuit with resource builders and typed edges
- document new examples in migration guide

## Testing
- `deno fmt docs/fluent/migration-guide.mdx examples/fluent/user-requirement-extract.ts examples/fluent/ur-workflows.ts`
- `deno lint docs/fluent/migration-guide.mdx examples/fluent/user-requirement-extract.ts examples/fluent/ur-workflows.ts`
- `deno check examples/fluent/user-requirement-extract.ts examples/fluent/ur-workflows.ts` *(fails: invalid peer certificate)*
- `deno task test` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_b_6896b096bd44832690cea291cd617000