### PR TITLE
docs: add fluent API guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@ provides the tools and infrastructure you need to bring your ideas to life.
 Join us in redefining what bots can do. Welcome to the future of bot building
 with Synaptic.
 
-## Fluent Builder Examples
+## Fluent API
 
-Synaptic now includes fluent builders for defining circuits directly in
-TypeScript. Check out the [migration guide](docs/fluent/migration-guide.mdx) and
-the [fluent examples](examples/fluent/basic-chat.ts) to get started.
+Synaptic's fluent API lets you construct resources, state, and circuits directly
+in TypeScript with strong typing and composability. It removes fragile JSON
+wiring and makes circuits easier to read and maintain.
+
+Start building with the [Fluent Quick Start](docs/fluent/quick-start.mdx) and
+explore the [migration examples](docs/fluent/migration-guide.mdx) for guidance
+on converting existing JSON circuits.
 
 Runtime packages under `*-synaptic-runtimes` also reference these examples to
 encourage adoption.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,6 +1,8 @@
 # Synaptic Runtimes
 
 Runtime packages built on Synaptic can leverage the new fluent circuit builders.
-See the [fluent examples](../examples/fluent/basic-chat.ts) for a
-self-contained circuit and the [migration guide](../docs/fluent/migration-guide.mdx)
-to convert existing JSON circuits.
+
+Get started with the [Fluent Quick Start](../docs/fluent/quick-start.mdx), then
+explore the [fluent examples](../examples/fluent/basic-chat.ts) for a
+self-contained circuit. To convert existing JSON circuits, follow the
+[migration guide](../docs/fluent/migration-guide.mdx).


### PR DESCRIPTION
## Summary
- highlight the Fluent API benefits and documentation
- point runtimes to quick start, examples, and migration guide

## Testing
- `deno fmt README.md runtime/README.md`
- `deno lint README.md runtime/README.md` *(fails: No target files found)*
- `deno task test` *(fails: invalid peer certificate fetching preact)*

------
https://chatgpt.com/codex/tasks/task_b_6896b39577bc832690858d50e5100281