### PR TITLE
refactor: capitalize circuit builder methods

### DIFF
--- a/docs/fluent/migration-guide.mdx
+++ b/docs/fluent/migration-guide.mdx
@@ -54,11 +54,11 @@ const agent = new ChatPromptNeuronBuilder("agent", {
 });
 
 const circuit = new GraphCircuitBuilder()
-  .state(state)
-  .neuron(agent)
-  .edge({ id: START } as any).to(agent)
-  .edge(agent).to(END)
-  .build();
+  .State(state)
+  .Neuron(agent)
+  .Edge({ id: START } as any).To(agent)
+  .Edge(agent).To(END)
+  .Build();
 ```
 
 The fluent version uses builders to define resources, state, and edges in a concise, expressive way. See the full example in [`examples/fluent/basic-chat.ts`](../../examples/fluent/basic-chat.ts).
@@ -149,10 +149,10 @@ const agent = new ChatPromptNeuronBuilder("agent", {
 const tool = new ToolNeuronBuilder("extract-tool", extractTool.id);
 
 const circuit = new LinearCircuitBuilder()
-  .neuron(agent)
-  .neuron(tool)
-  .chain(agent, tool)
-  .build();
+  .Neuron(agent)
+  .Neuron(tool)
+  .Chain(agent, tool)
+  .Build();
 ```
 
 Using `buildState` and `InputBuilder` provides typed state and inputs, while `persona.id` and `extractTool.id` remove fragile string lookups from the JSON version. See the full example in [`examples/fluent/user-requirement-extract.ts`](../../examples/fluent/user-requirement-extract.ts).
@@ -215,17 +215,17 @@ const c = new SimpleNeuron("c", "C");
 const d = new SimpleNeuron("d", "D");
 
 const circuit = new GraphCircuitBuilder()
-  .state(state)
-  .neuron(a)
-  .neuron(b)
-  .neuron(c)
-  .neuron(d)
-  .edge({ id: START } as any).to(a)
-  .edge(a).to([b, c])
-  .edge(b).to(d)
-  .edge(c).to(d)
-  .edge(d).to(END)
-  .build();
+  .State(state)
+  .Neuron(a)
+  .Neuron(b)
+  .Neuron(c)
+  .Neuron(d)
+  .Edge({ id: START } as any).To(a)
+  .Edge(a).To([b, c])
+  .Edge(b).To(d)
+  .Edge(c).To(d)
+  .Edge(d).To(END)
+  .Build();
 ```
 
 Edges now reference builder instances directly instead of string IDs, eliminating string lookups. See [`examples/fluent/graph-circuit-with-branching.ts`](../../examples/fluent/graph-circuit-with-branching.ts) for the complete example.
@@ -282,16 +282,16 @@ const agent = new ChatPromptNeuronBuilder("agent", {
 const tool = new ToolNeuronBuilder("search-tool", searchTool.id);
 
   const circuit = new GraphCircuitBuilder()
-    .state(state)
-    .neuron(agent)
-    .neuron(tool)
-    .edge({ id: START } as { id: typeof START }).to(agent)
-    .edge(agent).to({ [END]: END, tools: tool }, {
-    Condition: (s: { messages: string[] }) =>
-      s.messages.at(-1)?.includes("search") ? "tools" : END,
-  })
-  .edge(tool).to(agent)
-  .build();
+    .State(state)
+    .Neuron(agent)
+    .Neuron(tool)
+    .Edge({ id: START } as { id: typeof START }).To(agent)
+    .Edge(agent).To({ [END]: END, tools: tool }, {
+      Condition: (s: { messages: string[] }) =>
+        s.messages.at(-1)?.includes("search") ? "tools" : END,
+    })
+  .Edge(tool).To(agent)
+  .Build();
 ```
 
 See [`examples/fluent/ur-workflows.ts`](../../examples/fluent/ur-workflows.ts) for the full example.

--- a/docs/fluent/quick-start.mdx
+++ b/docs/fluent/quick-start.mdx
@@ -40,11 +40,11 @@ const agent = new ChatPromptNeuronBuilder("agent", {
 });
 
 const circuit = new GraphCircuitBuilder()
-  .state(state)
-  .neuron(agent)
-  .edge({ id: START } as any).to(agent)
-  .edge(agent).to(END)
-  .build();
+  .State(state)
+  .Neuron(agent)
+  .Edge({ id: START } as any).To(agent)
+  .Edge(agent).To(END)
+  .Build();
 
 export const eac = {
   AIs: {

--- a/docs/reference/GraphCircuitBuilder.mdx
+++ b/docs/reference/GraphCircuitBuilder.mdx
@@ -8,18 +8,18 @@ Assembles neurons into an arbitrary graph circuit.
 
 ## Methods
 
-- `state(state: StateDefinition): this` – attach a state schema.
-- `neuron(builder: NeuronBuilder): this` – register a neuron by its id.
-- `edge(from).to(target, options?)` – connect neurons with optional `EaCGraphCircuitEdge` options.
-- `build(): EaCGraphCircuitDetails` – create the circuit definition.
+- `State(state: StateDefinition): this` – attach a state schema.
+- `Neuron(builder: NeuronBuilder): this` – register a neuron by its id.
+- `Edge(from).To(target, options?)` – connect neurons with optional `EaCGraphCircuitEdge` options.
+- `Build(): EaCGraphCircuitDetails` – create the circuit definition.
 
 ## Example
 
 ```ts
 const circuit = new GraphCircuitBuilder()
-  .state(state)
-  .neuron(agent)
-  .edge({ id: START } as any).to(agent)
-  .edge(agent).to(END)
-  .build();
+  .State(state)
+  .Neuron(agent)
+  .Edge({ id: START } as any).To(agent)
+  .Edge(agent).To(END)
+  .Build();
 ```

--- a/docs/reference/LinearCircuitBuilder.mdx
+++ b/docs/reference/LinearCircuitBuilder.mdx
@@ -8,16 +8,16 @@ Creates simple linear sequences of neurons.
 
 ## Methods
 
-- `neuron(builder: NeuronBuilder): this` – add a neuron to the circuit.
-- `chain(...nodes: NeuronBuilder[])` – declare the ordered sequence to execute.
-- `build(): EaCLinearCircuitDetails` – output the circuit definition.
+- `Neuron(builder: NeuronBuilder): this` – add a neuron to the circuit.
+- `Chain(...nodes: NeuronBuilder[])` – declare the ordered sequence to execute.
+- `Build(): EaCLinearCircuitDetails` – output the circuit definition.
 
 ## Example
 
 ```ts
 const circuit = new LinearCircuitBuilder()
-  .neuron(a)
-  .neuron(b)
-  .chain(a, b)
-  .build();
+  .Neuron(a)
+  .Neuron(b)
+  .Chain(a, b)
+  .Build();
 ```

--- a/examples/fluent/basic-chat.ts
+++ b/examples/fluent/basic-chat.ts
@@ -27,13 +27,13 @@ const agent = new ChatPromptNeuronBuilder("agent", {
 
 // Assemble the graph circuit with explicit edges
 const circuit = new GraphCircuitBuilder()
-  .state(state)
-  .neuron(agent)
+  .State(state)
+  .Neuron(agent)
   // Start -> agent
-  .edge({ id: START } as any).to(agent)
+  .Edge({ id: START } as any).To(agent)
   // agent -> END
-  .edge(agent).to(END)
-  .build();
+  .Edge(agent).To(END)
+  .Build();
 
 // Export an EverythingAsCode fragment representing the circuit
 export const eac = {

--- a/examples/fluent/graph-circuit-with-branching.ts
+++ b/examples/fluent/graph-circuit-with-branching.ts
@@ -29,17 +29,17 @@ const c = new SimpleNeuron("c", "C");
 const d = new SimpleNeuron("d", "D");
 
 const circuit = new GraphCircuitBuilder()
-  .state(state)
-  .neuron(a)
-  .neuron(b)
-  .neuron(c)
-  .neuron(d)
-  .edge({ id: START } as any).to(a)
-  .edge(a).to([b, c])
-  .edge(b).to(d)
-  .edge(c).to(d)
-  .edge(d).to(END)
-  .build();
+  .State(state)
+  .Neuron(a)
+  .Neuron(b)
+  .Neuron(c)
+  .Neuron(d)
+  .Edge({ id: START } as any).To(a)
+  .Edge(a).To([b, c])
+  .Edge(b).To(d)
+  .Edge(c).To(d)
+  .Edge(d).To(END)
+  .Build();
 
 export const eac = {
   Circuits: {

--- a/examples/fluent/linear-circuit-with-tools.ts
+++ b/examples/fluent/linear-circuit-with-tools.ts
@@ -30,10 +30,10 @@ const tool = new ToolNeuronBuilder("extract-tool", extractTool.id);
 
 // Assemble the linear circuit
 const circuit = new LinearCircuitBuilder()
-  .neuron(agent)
-  .neuron(tool)
-  .chain(agent, tool)
-  .build();
+  .Neuron(agent)
+  .Neuron(tool)
+  .Chain(agent, tool)
+  .Build();
 
 // Export EverythingAsCode fragment
 export const eac = {

--- a/examples/fluent/ur-workflows.ts
+++ b/examples/fluent/ur-workflows.ts
@@ -49,18 +49,18 @@ const tool = new ToolNeuronBuilder("search-tool", searchTool.id);
 
 // Assemble the graph circuit with typed edges
 const circuit = new GraphCircuitBuilder()
-  .state(state)
-  .neuron(agent)
-  .neuron(tool)
-  .edge({ id: START } as { id: typeof START }).to(agent)
-  .edge(agent).to({ [END]: END, tools: tool }, {
+  .State(state)
+  .Neuron(agent)
+  .Neuron(tool)
+  .Edge({ id: START } as { id: typeof START }).To(agent)
+  .Edge(agent).To({ [END]: END, tools: tool }, {
     Condition: (s: { messages: string[] }) => {
       const last = s.messages.at(-1) ?? "";
       return last.includes("search") ? "tools" : END;
     },
   })
-  .edge(tool).to(agent)
-  .build();
+  .Edge(tool).To(agent)
+  .Build();
 
 // Export EverythingAsCode fragment
 export const eac = {

--- a/examples/fluent/user-requirement-extract.ts
+++ b/examples/fluent/user-requirement-extract.ts
@@ -47,10 +47,10 @@ const tool = new ToolNeuronBuilder("extract-tool", extractTool.id);
 
 // Assemble the linear circuit
 const circuit = new LinearCircuitBuilder()
-  .neuron(agent)
-  .neuron(tool)
-  .chain(agent, tool)
-  .build();
+  .Neuron(agent)
+  .Neuron(tool)
+  .Chain(agent, tool)
+  .Build();
 
 // Export EverythingAsCode fragment and typed input
 export const eac = {

--- a/src/fluent/circuits/GraphCircuitBuilder.ts
+++ b/src/fluent/circuits/GraphCircuitBuilder.ts
@@ -13,12 +13,12 @@ export class GraphCircuitBuilder<
   #neurons: Record<string, NeuronBuilder<any>> = {};
   #edges: Record<string, EaCGraphCircuitEdgeLike> = {};
 
-  state(state: StateDefinition): this {
+  State(state: StateDefinition): this {
     this.#state = state;
     return this;
   }
 
-  neuron<
+  Neuron<
     K extends string,
     N extends NeuronBuilder<any> & { id: K },
   >(builder: N): GraphCircuitBuilder<TNeurons & { [P in K]: N }> {
@@ -28,10 +28,10 @@ export class GraphCircuitBuilder<
     >;
   }
 
-  edge<From extends keyof TNeurons>(from: TNeurons[From]) {
+  Edge<From extends keyof TNeurons>(from: TNeurons[From]) {
     const fromId = from.id;
     return {
-      to: <
+      To: <
         Target extends
           | TNeurons[keyof TNeurons]
           | TNeurons[keyof TNeurons][]
@@ -64,7 +64,7 @@ export class GraphCircuitBuilder<
     };
   }
 
-  build(): EaCGraphCircuitDetails {
+  Build(): EaCGraphCircuitDetails {
     const neurons: Record<string, unknown> = {};
     for (const key in this.#neurons) {
       Object.assign(neurons, this.#neurons[key].build());

--- a/src/fluent/circuits/LinearCircuitBuilder.ts
+++ b/src/fluent/circuits/LinearCircuitBuilder.ts
@@ -7,7 +7,7 @@ export class LinearCircuitBuilder<
   #neurons: Record<string, NeuronBuilder<any>> = {};
   #sequence: string[] = [];
 
-  neuron<
+  Neuron<
     K extends string,
     N extends NeuronBuilder<any> & { id: K },
   >(builder: N): LinearCircuitBuilder<TNeurons & { [P in K]: N }> {
@@ -17,7 +17,7 @@ export class LinearCircuitBuilder<
     >;
   }
 
-  chain<
+  Chain<
     A extends TNeurons[keyof TNeurons],
     B extends TNeurons[keyof TNeurons],
     Rest extends TNeurons[keyof TNeurons][] = [],
@@ -26,7 +26,7 @@ export class LinearCircuitBuilder<
     return this;
   }
 
-  build(): EaCLinearCircuitDetails {
+  Build(): EaCLinearCircuitDetails {
     const neurons: Record<string, any> = {};
     for (const key in this.#neurons) {
       Object.assign(neurons, this.#neurons[key].build());

--- a/tests/fluent/graphs/graph-circuit-builder.tests.ts
+++ b/tests/fluent/graphs/graph-circuit-builder.tests.ts
@@ -14,11 +14,11 @@ Deno.test("GraphCircuitBuilder builds graph", () => {
   const tool = new ToolNeuronBuilder("tool", "t" as ToolId);
 
   const details = new GraphCircuitBuilder()
-    .neuron(agent)
-    .neuron(tool)
-    .edge(agent)
-    .to(tool)
-    .build();
+    .Neuron(agent)
+    .Neuron(tool)
+    .Edge(agent)
+    .To(tool)
+    .Build();
 
   assertEquals(Object.keys(details.Neurons ?? {}), ["agent", "tool"]);
   assertEquals(details.Edges.agent, "tool");

--- a/tests/fluent/linear/linear-circuit-builder.tests.ts
+++ b/tests/fluent/linear/linear-circuit-builder.tests.ts
@@ -14,10 +14,10 @@ Deno.test("LinearCircuitBuilder builds linear flow", () => {
   const tool = new ToolNeuronBuilder("tool", "t" as ToolId);
 
   const details = new LinearCircuitBuilder()
-    .neuron(agent)
-    .neuron(tool)
-    .chain(agent, tool)
-    .build();
+    .Neuron(agent)
+    .Neuron(tool)
+    .Chain(agent, tool)
+    .Build();
 
   assertEquals(details.Neurons[""], "agent");
   const agentDetails = details.Neurons["agent"] as { Neurons: Record<string, string> };


### PR DESCRIPTION
## Summary
- rename GraphCircuitBuilder methods to State/Neuron/Edge/Build and helper To
- rename LinearCircuitBuilder methods to Neuron/Chain/Build
- update tests, examples, and docs for new method names

## Testing
- `deno test -A tests/fluent/graphs/graph-circuit-builder.tests.ts tests/fluent/linear/linear-circuit-builder.tests.ts` *(failed: command not found: deno)*
- `curl -fsSL https://deno.land/install.sh | sh` *(failed: The requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_b_6896b805ea1c8326980879bc6b11a37b