### PR TITLE
refactor: rename build methods to Build

### DIFF
--- a/docs/fluent/quick-start.mdx
+++ b/docs/fluent/quick-start.mdx
@@ -48,7 +48,7 @@ const circuit = new GraphCircuitBuilder()
 
 export const eac = {
   AIs: {
-    example: { Personalities: pirate.build() },
+    example: { Personalities: pirate.Build() },
   },
   Circuits: {
     "basic-chat": { Details: circuit },

--- a/docs/reference/ChatHistoryBuilder.mdx
+++ b/docs/reference/ChatHistoryBuilder.mdx
@@ -15,11 +15,11 @@ Builds `ChatHistory` resources for EverythingAsCode.
 
 ## Methods
 
-- `build(): Record<string, EaCChatHistoryAsCode>` – export the resource in EverythingAsCode format.
+- `Build(): Record<string, EaCChatHistoryAsCode>` – export the resource in EverythingAsCode format.
 
 ## Example
 
 ```ts
 const history = new ChatHistoryBuilder("mem", { /* EaCChatHistoryDetails */ });
-const eac = history.build();
+const eac = history.Build();
 ```

--- a/docs/reference/ChatPromptNeuronBuilder.mdx
+++ b/docs/reference/ChatPromptNeuronBuilder.mdx
@@ -19,7 +19,7 @@ Builds a neuron that sends chat prompts to an LLM.
 
 ## Methods
 
-- `build(): Record<string, EaCChatPromptNeuron>` – EverythingAsCode fragment for the neuron.
+- `Build(): Record<string, EaCChatPromptNeuron>` – EverythingAsCode fragment for the neuron.
 
 ## Example
 
@@ -28,5 +28,5 @@ const agent = new ChatPromptNeuronBuilder("agent", {
   personality: persona.id,
   newMessages: [["human", "{input}"]],
 });
-const neuron = agent.build();
+const neuron = agent.Build();
 ```

--- a/docs/reference/DocumentLoaderBuilder.mdx
+++ b/docs/reference/DocumentLoaderBuilder.mdx
@@ -15,11 +15,11 @@ Defines `DocumentLoader` resources for loading raw documents.
 
 ## Methods
 
-- `build(): Record<string, EaCDocumentLoaderAsCode>` – EverythingAsCode output.
+- `Build(): Record<string, EaCDocumentLoaderAsCode>` – EverythingAsCode output.
 
 ## Example
 
 ```ts
 const loader = new DocumentLoaderBuilder("fs", { /* EaCDocumentLoaderDetails */ });
-const eac = loader.build();
+const eac = loader.Build();
 ```

--- a/docs/reference/EmbeddingsBuilder.mdx
+++ b/docs/reference/EmbeddingsBuilder.mdx
@@ -15,11 +15,11 @@ Creates `Embeddings` resources used for vector generation.
 
 ## Methods
 
-- `build(): Record<string, EaCEmbeddingsAsCode>` – produce EverythingAsCode output.
+- `Build(): Record<string, EaCEmbeddingsAsCode>` – produce EverythingAsCode output.
 
 ## Example
 
 ```ts
 const emb = new EmbeddingsBuilder("openai", { /* EaCEmbeddingsDetails */ });
-const eac = emb.build();
+const eac = emb.Build();
 ```

--- a/docs/reference/IndexerBuilder.mdx
+++ b/docs/reference/IndexerBuilder.mdx
@@ -15,11 +15,11 @@ Defines `Indexer` resources for ingesting documents.
 
 ## Methods
 
-- `build(): Record<string, EaCIndexerAsCode>` – export EverythingAsCode fragment.
+- `Build(): Record<string, EaCIndexerAsCode>` – export EverythingAsCode fragment.
 
 ## Example
 
 ```ts
 const indexer = new IndexerBuilder("basic", { /* EaCIndexerDetails */ });
-const eac = indexer.build();
+const eac = indexer.Build();
 ```

--- a/docs/reference/LLMBuilder.mdx
+++ b/docs/reference/LLMBuilder.mdx
@@ -15,11 +15,11 @@ Constructs Large Language Model resources.
 
 ## Methods
 
-- `build(): Record<string, EaCLLMAsCode>` – output EverythingAsCode fragment.
+- `Build(): Record<string, EaCLLMAsCode>` – output EverythingAsCode fragment.
 
 ## Example
 
 ```ts
 const llm = new LLMBuilder("openai", { /* EaCLLMDetails */ });
-const eac = llm.build();
+const eac = llm.Build();
 ```

--- a/docs/reference/NeuronBuilder.mdx
+++ b/docs/reference/NeuronBuilder.mdx
@@ -15,7 +15,7 @@ Abstract base for all neuron builders.
 
 ## Methods
 
-- `build(): Record<string, EaCNeuronLike>` – EverythingAsCode fragment for the neuron.
+- `Build(): Record<string, EaCNeuronLike>` – EverythingAsCode fragment for the neuron.
 
 ## Example
 

--- a/docs/reference/PersistenceBuilder.mdx
+++ b/docs/reference/PersistenceBuilder.mdx
@@ -15,11 +15,11 @@ Creates `Persistence` resources for storing state.
 
 ## Methods
 
-- `build(): Record<string, EaCPersistenceAsCode>` – build EverythingAsCode fragment.
+- `Build(): Record<string, EaCPersistenceAsCode>` – build EverythingAsCode fragment.
 
 ## Example
 
 ```ts
 const persistence = new PersistenceBuilder("kv", { /* EaCPersistenceDetails */ });
-const eac = persistence.build();
+const eac = persistence.Build();
 ```

--- a/docs/reference/PersonalityBuilder.mdx
+++ b/docs/reference/PersonalityBuilder.mdx
@@ -15,11 +15,11 @@ Creates `Personality` resources that influence agent behavior.
 
 ## Methods
 
-- `build(): Record<string, EaCPersonalityAsCode>` – EverythingAsCode output.
+- `Build(): Record<string, EaCPersonalityAsCode>` – EverythingAsCode output.
 
 ## Example
 
 ```ts
 const persona = new PersonalityBuilder("pirate", { Instructions: ["Talk like a pirate"] });
-const eac = persona.build();
+const eac = persona.Build();
 ```

--- a/docs/reference/ResourceBuilder.mdx
+++ b/docs/reference/ResourceBuilder.mdx
@@ -18,7 +18,7 @@ Creates a builder with an identifier and resource `details`.
 
 ## Methods
 
-- `protected buildAs(): Record<string, TAsCode>` – helper that produces the EverythingAsCode representation used by subclasses.
+- `protected BuildAs(): Record<string, TAsCode>` – helper that produces the EverythingAsCode representation used by subclasses.
 
 ## Example
 
@@ -28,8 +28,8 @@ class MyBuilder extends ResourceBuilder<MyDetails, MyAsCode, "My"> {
     super(lookup, details);
   }
 
-  build() {
-    return this.buildAs();
+  Build() {
+    return this.BuildAs();
   }
 }
 ```

--- a/docs/reference/RetrieverBuilder.mdx
+++ b/docs/reference/RetrieverBuilder.mdx
@@ -15,11 +15,11 @@ Creates `Retriever` resources for fetching relevant documents.
 
 ## Methods
 
-- `build(): Record<string, EaCRetrieverAsCode>` – EverythingAsCode fragment.
+- `Build(): Record<string, EaCRetrieverAsCode>` – EverythingAsCode fragment.
 
 ## Example
 
 ```ts
 const retriever = new RetrieverBuilder("vec", { /* EaCRetrieverDetails */ });
-const eac = retriever.build();
+const eac = retriever.Build();
 ```

--- a/docs/reference/TextSplitterBuilder.mdx
+++ b/docs/reference/TextSplitterBuilder.mdx
@@ -15,11 +15,11 @@ Creates `TextSplitter` resources for breaking text into chunks.
 
 ## Methods
 
-- `build(): Record<string, EaCTextSplitterAsCode>` – EverythingAsCode output.
+- `Build(): Record<string, EaCTextSplitterAsCode>` – EverythingAsCode output.
 
 ## Example
 
 ```ts
 const splitter = new TextSplitterBuilder("chars", { /* EaCTextSplitterDetails */ });
-const eac = splitter.build();
+const eac = splitter.Build();
 ```

--- a/docs/reference/ToolBuilder.mdx
+++ b/docs/reference/ToolBuilder.mdx
@@ -15,11 +15,11 @@ Defines `Tool` resources that can be invoked by neurons.
 
 ## Methods
 
-- `build(): Record<string, EaCToolAsCode>` – EverythingAsCode fragment.
+- `Build(): Record<string, EaCToolAsCode>` – EverythingAsCode fragment.
 
 ## Example
 
 ```ts
 const tool = new ToolBuilder("search", { /* EaCToolDetails */ });
-const eac = tool.build();
+const eac = tool.Build();
 ```

--- a/docs/reference/ToolNeuronBuilder.mdx
+++ b/docs/reference/ToolNeuronBuilder.mdx
@@ -15,11 +15,11 @@ Creates a neuron that invokes a registered tool.
 
 ## Methods
 
-- `build(): Record<string, EaCToolNeuron>` – EverythingAsCode fragment.
+- `Build(): Record<string, EaCToolNeuron>` – EverythingAsCode fragment.
 
 ## Example
 
 ```ts
 const neuron = new ToolNeuronBuilder("call-search", tool.id);
-const eac = neuron.build();
+const eac = neuron.Build();
 ```

--- a/docs/reference/VectorStoreBuilder.mdx
+++ b/docs/reference/VectorStoreBuilder.mdx
@@ -15,11 +15,11 @@ Creates `VectorStore` resources for embedding storage.
 
 ## Methods
 
-- `build(): Record<string, EaCVectorStoreAsCode>` – EverythingAsCode fragment.
+- `Build(): Record<string, EaCVectorStoreAsCode>` – EverythingAsCode fragment.
 
 ## Example
 
 ```ts
 const store = new VectorStoreBuilder("mem", { /* EaCVectorStoreDetails */ });
-const eac = store.build();
+const eac = store.Build();
 ```

--- a/examples/fluent/basic-chat.ts
+++ b/examples/fluent/basic-chat.ts
@@ -39,7 +39,7 @@ const circuit = new GraphCircuitBuilder()
 export const eac = {
   AIs: {
     example: {
-      Personalities: piratePersona.build(),
+      Personalities: piratePersona.Build(),
     },
   },
   Circuits: {

--- a/examples/fluent/linear-circuit-with-tools.ts
+++ b/examples/fluent/linear-circuit-with-tools.ts
@@ -39,8 +39,8 @@ const circuit = new LinearCircuitBuilder()
 export const eac = {
   AIs: {
     example: {
-      Personalities: persona.build(),
-      Tools: extractTool.build(),
+      Personalities: persona.Build(),
+      Tools: extractTool.Build(),
     },
   },
   Circuits: {

--- a/examples/fluent/ur-workflows.ts
+++ b/examples/fluent/ur-workflows.ts
@@ -66,9 +66,9 @@ const circuit = new GraphCircuitBuilder()
 export const eac = {
   AIs: {
     example: {
-      LLMs: llm.build(),
-      Personalities: persona.build(),
-      Tools: searchTool.build(),
+      LLMs: llm.Build(),
+      Personalities: persona.Build(),
+      Tools: searchTool.Build(),
     },
   },
   Circuits: {

--- a/examples/fluent/user-requirement-extract.ts
+++ b/examples/fluent/user-requirement-extract.ts
@@ -56,8 +56,8 @@ const circuit = new LinearCircuitBuilder()
 export const eac = {
   AIs: {
     example: {
-      Personalities: persona.build(),
-      Tools: extractTool.build(),
+      Personalities: persona.Build(),
+      Tools: extractTool.Build(),
     },
   },
   Circuits: {

--- a/src/fluent/circuits/GraphCircuitBuilder.ts
+++ b/src/fluent/circuits/GraphCircuitBuilder.ts
@@ -67,7 +67,7 @@ export class GraphCircuitBuilder<
   Build(): EaCGraphCircuitDetails {
     const neurons: Record<string, unknown> = {};
     for (const key in this.#neurons) {
-      Object.assign(neurons, this.#neurons[key].build());
+      Object.assign(neurons, this.#neurons[key].Build());
     }
 
     return {

--- a/src/fluent/circuits/LinearCircuitBuilder.ts
+++ b/src/fluent/circuits/LinearCircuitBuilder.ts
@@ -29,7 +29,7 @@ export class LinearCircuitBuilder<
   Build(): EaCLinearCircuitDetails {
     const neurons: Record<string, any> = {};
     for (const key in this.#neurons) {
-      Object.assign(neurons, this.#neurons[key].build());
+      Object.assign(neurons, this.#neurons[key].Build());
     }
 
     if (this.#sequence.length) {

--- a/src/fluent/circuits/neurons/NeuronBuilder.ts
+++ b/src/fluent/circuits/neurons/NeuronBuilder.ts
@@ -10,7 +10,7 @@ export abstract class NeuronBuilder<TDetails extends EaCNeuronLike> {
     this.id = lookup;
   }
 
-  build(): Record<string, TDetails> {
+  Build(): Record<string, TDetails> {
     return { [this.lookup]: this.details };
   }
 }

--- a/src/fluent/resources/ChatHistoryBuilder.ts
+++ b/src/fluent/resources/ChatHistoryBuilder.ts
@@ -11,7 +11,7 @@ export class ChatHistoryBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCChatHistoryAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCChatHistoryAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/DocumentLoaderBuilder.ts
+++ b/src/fluent/resources/DocumentLoaderBuilder.ts
@@ -11,7 +11,7 @@ export class DocumentLoaderBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCDocumentLoaderAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCDocumentLoaderAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/EmbeddingsBuilder.ts
+++ b/src/fluent/resources/EmbeddingsBuilder.ts
@@ -11,7 +11,7 @@ export class EmbeddingsBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCEmbeddingsAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCEmbeddingsAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/IndexerBuilder.ts
+++ b/src/fluent/resources/IndexerBuilder.ts
@@ -11,7 +11,7 @@ export class IndexerBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCIndexerAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCIndexerAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/LLMBuilder.ts
+++ b/src/fluent/resources/LLMBuilder.ts
@@ -11,7 +11,7 @@ export class LLMBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCLLMAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCLLMAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/PersistenceBuilder.ts
+++ b/src/fluent/resources/PersistenceBuilder.ts
@@ -11,7 +11,7 @@ export class PersistenceBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCPersistenceAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCPersistenceAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/PersonalityBuilder.ts
+++ b/src/fluent/resources/PersonalityBuilder.ts
@@ -11,7 +11,7 @@ export class PersonalityBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCPersonalityAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCPersonalityAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/ResourceBuilder.ts
+++ b/src/fluent/resources/ResourceBuilder.ts
@@ -16,7 +16,7 @@ export abstract class ResourceBuilder<
     this.id = lookup as Brand<string, TBrand>;
   }
 
-  protected buildAs(): Record<string, TAsCode> {
+  protected BuildAs(): Record<string, TAsCode> {
     return { [this.lookup]: { Details: this.details } as TAsCode };
   }
 }

--- a/src/fluent/resources/RetrieverBuilder.ts
+++ b/src/fluent/resources/RetrieverBuilder.ts
@@ -11,7 +11,7 @@ export class RetrieverBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCRetrieverAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCRetrieverAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/TextSplitterBuilder.ts
+++ b/src/fluent/resources/TextSplitterBuilder.ts
@@ -11,7 +11,7 @@ export class TextSplitterBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCTextSplitterAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCTextSplitterAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/ToolBuilder.ts
+++ b/src/fluent/resources/ToolBuilder.ts
@@ -11,7 +11,7 @@ export class ToolBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCToolAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCToolAsCode> {
+    return this.BuildAs();
   }
 }

--- a/src/fluent/resources/VectorStoreBuilder.ts
+++ b/src/fluent/resources/VectorStoreBuilder.ts
@@ -11,7 +11,7 @@ export class VectorStoreBuilder<
     super(lookup, details);
   }
 
-  build(): Record<string, EaCVectorStoreAsCode> {
-    return this.buildAs();
+  Build(): Record<string, EaCVectorStoreAsCode> {
+    return this.BuildAs();
   }
 }

--- a/tests/circuits/graphs/how-tos/force-calling-a-tool-first.ts
+++ b/tests/circuits/graphs/how-tos/force-calling-a-tool-first.ts
@@ -57,7 +57,7 @@ Deno.test("Graph Force Calling a Tool First Circuits", async (t) => {
           },
         },
         Tools: {
-          ...testTool.build(),
+          ...testTool.Build(),
         },
       },
     },


### PR DESCRIPTION
## Summary
- refactor neuron builder to use `Build` instead of `build`
- rename resource builder helper to `BuildAs` and expose `Build` in subclasses
- update tests, docs, and examples to call `Build`

## Testing
- `deno test -A` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6896b98ab1f883269d1e96124c08e823