### PR TITLE
Rename buildState helper to BuildState

### DIFF
--- a/docs/fluent/migration-guide.mdx
+++ b/docs/fluent/migration-guide.mdx
@@ -35,13 +35,13 @@ import {
   GraphCircuitBuilder,
 } from "../../src/fluent/circuits/_exports.ts";
 import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
-import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+import { BuildState } from "../../src/fluent/state/StateBuilder.ts";
 
 const persona = new PersonalityBuilder("pirate", {
   Instructions: ["Answer like a pirate"],
 });
 
-const state = buildState((s) =>
+const state = BuildState((s) =>
   s.Field("messages", {
     reducer: (x: string[], y: string[]) => x.concat(y),
     default: () => [],
@@ -112,10 +112,10 @@ import {
 } from "../../src/fluent/circuits/_exports.ts";
 import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
 import { ToolBuilder } from "../../src/fluent/resources/ToolBuilder.ts";
-import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+import { BuildState } from "../../src/fluent/state/StateBuilder.ts";
 import { InputBuilder } from "../../src/fluent/state/InputBuilder.ts";
 
-const state = buildState((s) =>
+const state = BuildState((s) =>
   s.Field("text", {
     reducer: (_x, y: string) => y,
     default: () => "",
@@ -155,7 +155,7 @@ const circuit = new LinearCircuitBuilder()
   .Build();
 ```
 
-Using `buildState` and `InputBuilder` provides typed state and inputs, while `persona.id` and `extractTool.id` remove fragile string lookups from the JSON version. See the full example in [`examples/fluent/user-requirement-extract.ts`](../../examples/fluent/user-requirement-extract.ts).
+Using `BuildState` and `InputBuilder` provides typed state and inputs, while `persona.id` and `extractTool.id` remove fragile string lookups from the JSON version. See the full example in [`examples/fluent/user-requirement-extract.ts`](../../examples/fluent/user-requirement-extract.ts).
 
 
 ## Graph circuit with branching
@@ -247,7 +247,7 @@ import {
   PersonalityBuilder,
   ToolBuilder,
 } from "../../src/fluent/resources/index.ts";
-import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+import { BuildState } from "../../src/fluent/state/StateBuilder.ts";
 
 const llm = new LLMBuilder("thinky-llm", {
   Type: "OpenAI",
@@ -267,7 +267,7 @@ const persona = new PersonalityBuilder("workflow-analyst", {
     Action: ({ query }: { query: string }) => `results for ${query}`,
   });
 
-const state = buildState((s) =>
+const state = BuildState((s) =>
   s.Field("messages", {
     reducer: (x: string[], y: string[]) => x.concat(y),
     default: () => [],

--- a/docs/fluent/quick-start.mdx
+++ b/docs/fluent/quick-start.mdx
@@ -21,13 +21,13 @@ The snippet below assembles a simple chat circuit and exports an EverythingAsCod
 import { Annotation, START, END } from "npm:@langchain/langgraph@0.2.56";
 import { GraphCircuitBuilder, ChatPromptNeuronBuilder } from "../../src/fluent/circuits/_exports.ts";
 import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
-import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+import { BuildState } from "../../src/fluent/state/StateBuilder.ts";
 
 const pirate = new PersonalityBuilder("pirate", {
   Instructions: ["Answer like a pirate"],
 });
 
-const state = buildState((s) =>
+const state = BuildState((s) =>
   s.Field("messages", {
     reducer: (x: string[], y: string[]) => x.concat(y),
     default: () => [],

--- a/docs/reference/StateBuilder.mdx
+++ b/docs/reference/StateBuilder.mdx
@@ -13,12 +13,12 @@ Describes the state schema for a circuit.
 
 ### Helper
 
-`buildState(builder: (sb: StateBuilder) => StateBuilder): Record<string, Annotation>` wraps the builder pattern.
+`BuildState(builder: (sb: StateBuilder) => StateBuilder): Record<string, Annotation>` wraps the builder pattern.
 
 ## Example
 
 ```ts
-const state = buildState((s) =>
+const state = BuildState((s) =>
   s.Field("messages", {
     reducer: (x: string[], y: string[]) => x.concat(y),
     default: () => [],

--- a/examples/fluent/basic-chat.ts
+++ b/examples/fluent/basic-chat.ts
@@ -4,7 +4,7 @@ import {
   GraphCircuitBuilder,
 } from "../../src/fluent/circuits/_exports.ts";
 import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
-import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+import { BuildState } from "../../src/fluent/state/StateBuilder.ts";
 
 // Define a personality resource that the chat prompt will use
 const piratePersona = new PersonalityBuilder("pirate", {
@@ -12,7 +12,7 @@ const piratePersona = new PersonalityBuilder("pirate", {
 });
 
 // Describe the circuit state: an accumulating list of messages
-const state = buildState((s) =>
+const state = BuildState((s) =>
   s.Field("messages", {
     reducer: (x: string[], y: string[]) => x.concat(y),
     default: () => [],

--- a/examples/fluent/ur-workflows.ts
+++ b/examples/fluent/ur-workflows.ts
@@ -10,7 +10,7 @@ import {
   PersonalityBuilder,
   ToolBuilder,
 } from "../../src/fluent/resources/index.ts";
-import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+import { BuildState } from "../../src/fluent/state/StateBuilder.ts";
 
 // Define resources
 const llm = new LLMBuilder("thinky-llm", {
@@ -32,7 +32,7 @@ const searchTool = new ToolBuilder("search", {
 });
 
 // Circuit state
-const state = buildState((s) =>
+const state = BuildState((s) =>
   s.Field("messages", {
     reducer: (x: string[], y: string[]) => x.concat(y),
     default: () => [],

--- a/examples/fluent/user-requirement-extract.ts
+++ b/examples/fluent/user-requirement-extract.ts
@@ -6,11 +6,11 @@ import {
 } from "../../src/fluent/circuits/_exports.ts";
 import { PersonalityBuilder } from "../../src/fluent/resources/PersonalityBuilder.ts";
 import { ToolBuilder } from "../../src/fluent/resources/ToolBuilder.ts";
-import { buildState } from "../../src/fluent/state/StateBuilder.ts";
+import { BuildState } from "../../src/fluent/state/StateBuilder.ts";
 import { InputBuilder } from "../../src/fluent/state/InputBuilder.ts";
 
 // Define circuit state and typed input
-const state = buildState((s) =>
+const state = BuildState((s) =>
   s.Field("text", {
     reducer: (_x, y: string) => y,
     default: () => "",

--- a/src/fluent/state/StateBuilder.ts
+++ b/src/fluent/state/StateBuilder.ts
@@ -27,7 +27,7 @@ export class StateBuilder<
   }
 }
 
-export function buildState<T>(
+export function BuildState<T>(
   builder: (sb: StateBuilder) => StateBuilder<T>,
 ): Record<string, ReturnType<typeof Annotation>> {
   const sb = builder(new StateBuilder());


### PR DESCRIPTION
## Summary
- rename `buildState` helper to `BuildState`
- use `BuildState` in examples and documentation

## Testing
- `deno fmt src/fluent/state/StateBuilder.ts examples/fluent/basic-chat.ts examples/fluent/ur-workflows.ts examples/fluent/user-requirement-extract.ts docs/reference/StateBuilder.mdx docs/fluent/migration-guide.mdx docs/fluent/quick-start.mdx` *(fails: command not found)*
- `deno lint src/fluent/state/StateBuilder.ts examples/fluent/basic-chat.ts examples/fluent/ur-workflows.ts examples/fluent/user-requirement-extract.ts` *(fails: command not found)*
- `deno test tests/fluent/state/state-builder.tests.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6896bd8b0b7c832690e174f46ab47982