### PR TITLE
feat: enforce details constraints on builders

### DIFF
--- a/src/fluent/resources/ChatHistoryBuilder.ts
+++ b/src/fluent/resources/ChatHistoryBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCChatHistoryAsCode } from "../../eac/EaCChatHistoryAsCode.ts";
 import { EaCChatHistoryDetails } from "../../eac/EaCChatHistoryDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type ChatHistoryId = Brand<string, "ChatHistory">;
 
 export class ChatHistoryBuilder<
   TDetails extends EaCChatHistoryDetails = EaCChatHistoryDetails,
-> extends ResourceBuilder<TDetails, EaCChatHistoryAsCode, "ChatHistory"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "ChatHistory"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCChatHistoryAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/DocumentLoaderBuilder.ts
+++ b/src/fluent/resources/DocumentLoaderBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCDocumentLoaderAsCode } from "../../eac/EaCDocumentLoaderAsCode.ts";
 import { EaCDocumentLoaderDetails } from "../../eac/EaCDocumentLoaderDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type DocumentLoaderId = Brand<string, "DocumentLoader">;
 
 export class DocumentLoaderBuilder<
   TDetails extends EaCDocumentLoaderDetails = EaCDocumentLoaderDetails,
-> extends ResourceBuilder<TDetails, EaCDocumentLoaderAsCode, "DocumentLoader"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "DocumentLoader"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCDocumentLoaderAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/EmbeddingsBuilder.ts
+++ b/src/fluent/resources/EmbeddingsBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCEmbeddingsAsCode } from "../../eac/EaCEmbeddingsAsCode.ts";
 import { EaCEmbeddingsDetails } from "../../eac/EaCEmbeddingsDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type EmbeddingsId = Brand<string, "Embeddings">;
 
 export class EmbeddingsBuilder<
   TDetails extends EaCEmbeddingsDetails = EaCEmbeddingsDetails,
-> extends ResourceBuilder<TDetails, EaCEmbeddingsAsCode, "Embeddings"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "Embeddings"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCEmbeddingsAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/IndexerBuilder.ts
+++ b/src/fluent/resources/IndexerBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCIndexerAsCode } from "../../eac/EaCIndexerAsCode.ts";
 import { EaCIndexerDetails } from "../../eac/EaCIndexerDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type IndexerId = Brand<string, "Indexer">;
 
 export class IndexerBuilder<
   TDetails extends EaCIndexerDetails = EaCIndexerDetails,
-> extends ResourceBuilder<TDetails, EaCIndexerAsCode, "Indexer"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "Indexer"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCIndexerAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/LLMBuilder.ts
+++ b/src/fluent/resources/LLMBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCLLMAsCode } from "../../eac/llms/EaCLLMAsCode.ts";
 import { EaCLLMDetails } from "../../eac/llms/EaCLLMDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type LLMId = Brand<string, "LLM">;
 
 export class LLMBuilder<
   TDetails extends EaCLLMDetails = EaCLLMDetails,
-> extends ResourceBuilder<TDetails, EaCLLMAsCode, "LLM"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "LLM"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCLLMAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/PersistenceBuilder.ts
+++ b/src/fluent/resources/PersistenceBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCPersistenceAsCode } from "../../eac/EaCPersistenceAsCode.ts";
 import { EaCPersistenceDetails } from "../../eac/EaCPersistenceDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type PersistenceId = Brand<string, "Persistence">;
 
 export class PersistenceBuilder<
   TDetails extends EaCPersistenceDetails = EaCPersistenceDetails,
-> extends ResourceBuilder<TDetails, EaCPersistenceAsCode, "Persistence"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "Persistence"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCPersistenceAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/PersonalityBuilder.ts
+++ b/src/fluent/resources/PersonalityBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCPersonalityAsCode } from "../../eac/EaCPersonalityAsCode.ts";
 import { EaCPersonalityDetails } from "../../eac/EaCPersonalityDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type PersonalityId = Brand<string, "Personality">;
 
 export class PersonalityBuilder<
   TDetails extends EaCPersonalityDetails = EaCPersonalityDetails,
-> extends ResourceBuilder<TDetails, EaCPersonalityAsCode, "Personality"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "Personality"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCPersonalityAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/ResourceBuilder.ts
+++ b/src/fluent/resources/ResourceBuilder.ts
@@ -1,9 +1,9 @@
-import { EaCDetails } from "../../src.deps.ts";
+import { EaCDetails, EaCVertexDetails } from "../../src.deps.ts";
 
 export type Brand<T, B extends string> = T & { __brand: B };
 
 export abstract class ResourceBuilder<
-  TDetails,
+  TDetails extends EaCVertexDetails,
   TAsCode extends EaCDetails<TDetails>,
   TBrand extends string,
 > {

--- a/src/fluent/resources/RetrieverBuilder.ts
+++ b/src/fluent/resources/RetrieverBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCRetrieverAsCode } from "../../eac/EaCRetrieverAsCode.ts";
 import { EaCRetrieverDetails } from "../../eac/EaCRetrieverDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type RetrieverId = Brand<string, "Retriever">;
 
 export class RetrieverBuilder<
   TDetails extends EaCRetrieverDetails = EaCRetrieverDetails,
-> extends ResourceBuilder<TDetails, EaCRetrieverAsCode, "Retriever"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "Retriever"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCRetrieverAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/TextSplitterBuilder.ts
+++ b/src/fluent/resources/TextSplitterBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCTextSplitterAsCode } from "../../eac/EaCTextSplitterAsCode.ts";
 import { EaCTextSplitterDetails } from "../../eac/EaCTextSplitterDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type TextSplitterId = Brand<string, "TextSplitter">;
 
 export class TextSplitterBuilder<
   TDetails extends EaCTextSplitterDetails = EaCTextSplitterDetails,
-> extends ResourceBuilder<TDetails, EaCTextSplitterAsCode, "TextSplitter"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "TextSplitter"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCTextSplitterAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/ToolBuilder.ts
+++ b/src/fluent/resources/ToolBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCToolAsCode } from "../../eac/EaCToolAsCode.ts";
 import { EaCToolDetails } from "../../eac/EaCToolDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type ToolId = Brand<string, "Tool">;
 
 export class ToolBuilder<
   TDetails extends EaCToolDetails = EaCToolDetails,
-> extends ResourceBuilder<TDetails, EaCToolAsCode, "Tool"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "Tool"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCToolAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }

--- a/src/fluent/resources/VectorStoreBuilder.ts
+++ b/src/fluent/resources/VectorStoreBuilder.ts
@@ -1,17 +1,17 @@
-import { EaCVectorStoreAsCode } from "../../eac/EaCVectorStoreAsCode.ts";
 import { EaCVectorStoreDetails } from "../../eac/EaCVectorStoreDetails.ts";
+import { EaCDetails } from "../../src.deps.ts";
 import { Brand, ResourceBuilder } from "./ResourceBuilder.ts";
 
 export type VectorStoreId = Brand<string, "VectorStore">;
 
 export class VectorStoreBuilder<
   TDetails extends EaCVectorStoreDetails = EaCVectorStoreDetails,
-> extends ResourceBuilder<TDetails, EaCVectorStoreAsCode, "VectorStore"> {
+> extends ResourceBuilder<TDetails, EaCDetails<TDetails>, "VectorStore"> {
   constructor(lookup: string, details: TDetails) {
     super(lookup, details);
   }
 
-  Build(): Record<string, EaCVectorStoreAsCode> {
+  Build(): Record<string, EaCDetails<TDetails>> {
     return this.BuildAs();
   }
 }


### PR DESCRIPTION
## Summary
- constrain `ResourceBuilder` generics to EaC details types
- thread EaC detail generics through resource builders

## Testing
- `deno task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6896ce5d0ea88326a782b7086d0344be