### PR TITLE
feat: resolve neuron builders to ids for graph edges

### DIFF
--- a/tests/fluent/graphs/graph-circuit-builder.tests.ts
+++ b/tests/fluent/graphs/graph-circuit-builder.tests.ts
@@ -24,3 +24,22 @@ Deno.test("GraphCircuitBuilder builds graph", () => {
   assertEquals(details.Edges.agent, "tool");
   assertEquals(details.Type, "Graph");
 });
+
+Deno.test("GraphCircuitBuilder converts neuron builders to ids", () => {
+  const agent = new ChatPromptNeuronBuilder("agent", {
+    personality: "p" as PersonalityId,
+  });
+  const tool = new ToolNeuronBuilder("tool", "t" as ToolId);
+
+  const details = new GraphCircuitBuilder()
+    .Neuron(agent)
+    .Neuron(tool)
+    .Edge(agent)
+    .To([tool, agent.id])
+    .Edge(tool)
+    .To({ next: agent })
+    .Build();
+
+  assertEquals(details.Edges.agent, ["tool", "agent"]);
+  assertEquals(details.Edges.tool, { Node: { next: "agent" } });
+});


### PR DESCRIPTION
## Summary
- add helper to coerce `NeuronBuilder` references into string IDs
- update `GraphCircuitBuilder.Edge` to use string IDs internally
- add tests covering array and record targets

## Testing
- `deno test tests/fluent/graphs/graph-circuit-builder.tests.ts tests/fluent/linear/linear-circuit-builder.tests.ts --allow-all` *(failed: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_b_6896cfc5da4c8326acff888c678831aa