### PR TITLE
feat: tighten BuildState typing and add inference tests

### DIFF
--- a/src/fluent/state/StateBuilder.ts
+++ b/src/fluent/state/StateBuilder.ts
@@ -16,7 +16,7 @@ export class StateBuilder<
   ): StateBuilder<TState & Record<K, V>> {
     this.schema[name] = Annotation<V>({
       default: options.default,
-      reducer: options.reducer,
+      reducer: options.reducer ?? ((_, update) => update),
     });
 
     return this as unknown as StateBuilder<TState & Record<K, V>>;
@@ -27,7 +27,7 @@ export class StateBuilder<
   }
 }
 
-export function BuildState<T>(
+export function BuildState<T extends Record<string, unknown>>(
   builder: (sb: StateBuilder) => StateBuilder<T>,
 ): Record<string, ReturnType<typeof Annotation>> {
   const sb = builder(new StateBuilder());

--- a/tests/fluent/state/state-builder.tests.ts
+++ b/tests/fluent/state/state-builder.tests.ts
@@ -1,7 +1,33 @@
 import { assertEquals, z, zodToJsonSchema } from "../../tests.deps.ts";
-import { InputBuilder, StateBuilder } from "../../../mod.ts";
+import {
+  BuildState,
+  InferSynapticState,
+  InputBuilder,
+  StateBuilder,
+} from "../../../mod.ts";
 
-Deno.test("State and Input builders", () => {
+Deno.test("BuildState infers state type", () => {
+  const state = BuildState((s) =>
+    s.Field("messages", {
+      reducer: (x: string[], y: string[]) => x.concat(y),
+      default: () => [],
+    }).Field("count", {
+      reducer: (x: number, y: number) => x + y,
+      default: () => 0,
+    })
+  );
+
+  type InferredState = InferSynapticState<typeof state>;
+
+  const sample: InferredState = {
+    messages: ["hi"],
+    count: 1,
+  };
+
+  assertEquals(sample.count, 1);
+});
+
+Deno.test("State and Input builders generate Zod schema", () => {
   const state = new StateBuilder()
     .Field("messages", {
       reducer: (x: string[], y: string[]) => x.concat(y),


### PR DESCRIPTION
## Summary
- ensure BuildState generics extend Record
- provide default reducer in StateBuilder.Field so annotations always get a function
- add tests covering state type inference and Zod schema creation

## Testing
- `deno test -A tests/fluent/state/state-builder.tests.ts` *(fails: command not found)*
- `apt-get install -y deno` *(fails: Unable to locate package deno)*
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6896d2ef29448326bd1216d9c895beef