### PR TITLE
feat: accept raw lookup strings for token helpers

### DIFF
--- a/src/fluent/lookups/index.ts
+++ b/src/fluent/lookups/index.ts
@@ -32,7 +32,15 @@ export function Circuit(lookup: string, scope: string): CircuitLookupToken {
 
 export type ChatHistoryLookupToken = LookupToken<"ChatHistory">;
 export function ChatHistory(
+  lookup: string,
+  scope: string,
+): ChatHistoryLookupToken;
+export function ChatHistory(
   lookup: ChatHistoryId,
+  scope: string,
+): ChatHistoryLookupToken;
+export function ChatHistory(
+  lookup: string | ChatHistoryId,
   scope: string,
 ): ChatHistoryLookupToken {
   return scoped<"ChatHistory">(lookup, scope);
@@ -40,7 +48,15 @@ export function ChatHistory(
 
 export type DocumentLoaderLookupToken = LookupToken<"DocumentLoader">;
 export function DocumentLoader(
+  lookup: string,
+  scope: string,
+): DocumentLoaderLookupToken;
+export function DocumentLoader(
   lookup: DocumentLoaderId,
+  scope: string,
+): DocumentLoaderLookupToken;
+export function DocumentLoader(
+  lookup: string | DocumentLoaderId,
   scope: string,
 ): DocumentLoaderLookupToken {
   return scoped<"DocumentLoader">(lookup, scope);
@@ -48,7 +64,15 @@ export function DocumentLoader(
 
 export type EmbeddingsLookupToken = LookupToken<"Embeddings">;
 export function Embeddings(
+  lookup: string,
+  scope: string,
+): EmbeddingsLookupToken;
+export function Embeddings(
   lookup: EmbeddingsId,
+  scope: string,
+): EmbeddingsLookupToken;
+export function Embeddings(
+  lookup: string | EmbeddingsId,
   scope: string,
 ): EmbeddingsLookupToken {
   return scoped<"Embeddings">(lookup, scope);
@@ -56,20 +80,41 @@ export function Embeddings(
 
 export type IndexerLookupToken = LookupToken<"Indexer">;
 export function Indexer(
+  lookup: string,
+  scope: string,
+): IndexerLookupToken;
+export function Indexer(
   lookup: IndexerId,
+  scope: string,
+): IndexerLookupToken;
+export function Indexer(
+  lookup: string | IndexerId,
   scope: string,
 ): IndexerLookupToken {
   return scoped<"Indexer">(lookup, scope);
 }
 
 export type LLMLookupToken = LookupToken<"LLM">;
-export function LLM(lookup: LLMId, scope: string): LLMLookupToken {
+export function LLM(lookup: string, scope: string): LLMLookupToken;
+export function LLM(lookup: LLMId, scope: string): LLMLookupToken;
+export function LLM(
+  lookup: string | LLMId,
+  scope: string,
+): LLMLookupToken {
   return scoped<"LLM">(lookup, scope);
 }
 
 export type PersistenceLookupToken = LookupToken<"Persistence">;
 export function Persistence(
+  lookup: string,
+  scope: string,
+): PersistenceLookupToken;
+export function Persistence(
   lookup: PersistenceId,
+  scope: string,
+): PersistenceLookupToken;
+export function Persistence(
+  lookup: string | PersistenceId,
   scope: string,
 ): PersistenceLookupToken {
   return scoped<"Persistence">(lookup, scope);
@@ -77,7 +122,15 @@ export function Persistence(
 
 export type PersonalityLookupToken = LookupToken<"Personality">;
 export function Personality(
+  lookup: string,
+  scope: string,
+): PersonalityLookupToken;
+export function Personality(
   lookup: PersonalityId,
+  scope: string,
+): PersonalityLookupToken;
+export function Personality(
+  lookup: string | PersonalityId,
   scope: string,
 ): PersonalityLookupToken {
   return scoped<"Personality">(lookup, scope);
@@ -85,7 +138,15 @@ export function Personality(
 
 export type RetrieverLookupToken = LookupToken<"Retriever">;
 export function Retriever(
+  lookup: string,
+  scope: string,
+): RetrieverLookupToken;
+export function Retriever(
   lookup: RetrieverId,
+  scope: string,
+): RetrieverLookupToken;
+export function Retriever(
+  lookup: string | RetrieverId,
   scope: string,
 ): RetrieverLookupToken {
   return scoped<"Retriever">(lookup, scope);
@@ -93,20 +154,41 @@ export function Retriever(
 
 export type TextSplitterLookupToken = LookupToken<"TextSplitter">;
 export function TextSplitter(
+  lookup: string,
+  scope: string,
+): TextSplitterLookupToken;
+export function TextSplitter(
   lookup: TextSplitterId,
+  scope: string,
+): TextSplitterLookupToken;
+export function TextSplitter(
+  lookup: string | TextSplitterId,
   scope: string,
 ): TextSplitterLookupToken {
   return scoped<"TextSplitter">(lookup, scope);
 }
 
 export type ToolLookupToken = LookupToken<"Tool">;
-export function Tool(lookup: ToolId, scope: string): ToolLookupToken {
+export function Tool(lookup: string, scope: string): ToolLookupToken;
+export function Tool(lookup: ToolId, scope: string): ToolLookupToken;
+export function Tool(
+  lookup: string | ToolId,
+  scope: string,
+): ToolLookupToken {
   return scoped<"Tool">(lookup, scope);
 }
 
 export type VectorStoreLookupToken = LookupToken<"VectorStore">;
 export function VectorStore(
+  lookup: string,
+  scope: string,
+): VectorStoreLookupToken;
+export function VectorStore(
   lookup: VectorStoreId,
+  scope: string,
+): VectorStoreLookupToken;
+export function VectorStore(
+  lookup: string | VectorStoreId,
   scope: string,
 ): VectorStoreLookupToken {
   return scoped<"VectorStore">(lookup, scope);

--- a/src/plugins/FathymSynapticPlugin.ts
+++ b/src/plugins/FathymSynapticPlugin.ts
@@ -807,7 +807,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
                       details.LoaderLookups.map(async (loaderLookup) => {
                         const loader = await ioc.Resolve<BaseDocumentLoader>(
                           ioc.Symbol("DocumentLoader"),
-                          loaderLookup,
+                          documentLoaderToken(loaderLookup, aiLookup),
                         );
 
                         return await loader.load();
@@ -1001,7 +1001,10 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
 
             const vectorStore = await ioc.Resolve<VectorStore>(
               ioc.Symbol(VectorStore.name),
-              retriever.Details!.VectorStoreLookup,
+              vectorStoreToken(
+                retriever.Details!.VectorStoreLookup,
+                aiLookup,
+              ),
             );
 
             await ioc.Register(() => vectorStore.asRetriever(), {
@@ -1217,7 +1220,7 @@ export default class FathymSynapticPlugin implements EaCRuntimePlugin {
 
           const embeddings = await ioc.Resolve<Embeddings>(
             ioc.Symbol(Embeddings.name),
-            vectorStore.Details!.EmbeddingsLookup,
+            embeddingsToken(vectorStore.Details!.EmbeddingsLookup, aiLookup),
           );
 
           if (isEaCAzureSearchAIVectorStoreDetails(vectorStore.Details)) {


### PR DESCRIPTION
## Summary
- allow token helper functions to take raw string IDs and brand them
- resolve document loaders, vector stores, and embeddings using branded lookup tokens

## Testing
- `deno task build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6896d4594a0c8326a51d5aed79aa2db9