### PR TITLE
feat(state): widen state builder annotations

### DIFF
--- a/src/fluent/state/StateBuilder.ts
+++ b/src/fluent/state/StateBuilder.ts
@@ -1,4 +1,4 @@
-import { Annotation } from "../../src.deps.ts";
+import { Annotation, type BinaryOperatorAggregate } from "../../src.deps.ts";
 
 export interface StateBuilderFieldOptions<T> {
   reducer?: (state: T, update: T) => T;
@@ -8,28 +8,33 @@ export interface StateBuilderFieldOptions<T> {
 export class StateBuilder<
   TState extends Record<string, unknown> = Record<PropertyKey, never>,
 > {
-  protected schema: Record<string, ReturnType<typeof Annotation>> = {};
+  // deno-lint-ignore no-explicit-any
+  protected schema: Record<string, BinaryOperatorAggregate<any, any>> = {};
 
   Field<K extends string, V>(
     name: K,
     options: StateBuilderFieldOptions<V>,
   ): StateBuilder<TState & Record<K, V>> {
-    this.schema[name] = Annotation<V>({
+    const field = Annotation<V>({
       default: options.default,
       reducer: options.reducer ?? ((_, update) => update),
     });
+    // deno-lint-ignore no-explicit-any
+    this.schema[name] = field as BinaryOperatorAggregate<any, any>;
 
     return this as unknown as StateBuilder<TState & Record<K, V>>;
   }
 
-  Build() {
+  // deno-lint-ignore no-explicit-any
+  Build(): Record<string, BinaryOperatorAggregate<any, any>> {
     return this.schema;
   }
 }
 
 export function BuildState<T extends Record<string, unknown>>(
   builder: (sb: StateBuilder) => StateBuilder<T>,
-): Record<string, ReturnType<typeof Annotation>> {
+  // deno-lint-ignore no-explicit-any
+): Record<string, BinaryOperatorAggregate<any, any>> {
   const sb = builder(new StateBuilder());
   return sb.Build();
 }

--- a/src/langgraph.deps.ts
+++ b/src/langgraph.deps.ts
@@ -2,6 +2,7 @@ export {
   Annotation,
   BaseChannel,
   BaseCheckpointSaver,
+  type BinaryOperatorAggregate,
   type Checkpoint,
   type CheckpointMetadata,
   MemorySaver,


### PR DESCRIPTION
## Summary
- expose BinaryOperatorAggregate from langgraph deps
- allow StateBuilder schema to store generic BinaryOperatorAggregate annotations

## Testing
- `deno lint`
- `deno task build` *(fails: invalid peer certificate: Unknown Issuer)*

------
https://chatgpt.com/codex/tasks/task_b_6896d7a490a88326ae5f01d1cae226df